### PR TITLE
UI updates to SavedSearchesPage

### DIFF
--- a/GitHubExtension/GitHubExtensionCommandsProvider.cs
+++ b/GitHubExtension/GitHubExtensionCommandsProvider.cs
@@ -50,8 +50,8 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider
             },
             new CommandItem(new SavedSearchesPage())
             {
-                Title = "Saved Searches",
-                Icon = new IconInfo("\ue74e"),
+                Title = "Saved GitHub Searches",
+                Icon = new IconInfo("\ue721"),
             },
         ]
         : [

--- a/GitHubExtension/Pages/SavedSearchesPage.cs
+++ b/GitHubExtension/Pages/SavedSearchesPage.cs
@@ -27,8 +27,8 @@ internal sealed partial class SavedSearchesPage : ListPage
 
     public SavedSearchesPage()
     {
-        Icon = new IconInfo("\ue74e");
-        Name = "Saved Searches";
+        Icon = new IconInfo("\ue721");
+        Name = "Saved GitHub Searches";
         SaveSearchForm.SearchSaved += OnSearchSaved;
         RemoveSavedSearchCommand.SearchRemoved += OnSearchRemoved;
         RemoveSavedSearchCommand.SearchRemoving += OnSearchRemoving;


### PR DESCRIPTION
Closes #26 

This pull request includes several updates to the `SavedSearchesPage` functionality and user interface. The most important changes include updating titles and icons, adding new search list items, and refactoring the method for retrieving items.

Updates to titles and icons:

* [`GitHubExtension/GitHubExtensionCommandsProvider.cs`](diffhunk://#diff-4cc9299b4a7b0fd718219238a897679ec58d14835f558553a95b02ba0f5ed469L53-R54): Changed the title from "Saved Searches" to "Saved GitHub Searches" and updated the icon.
* [`GitHubExtension/Pages/SavedSearchesPage.cs`](diffhunk://#diff-8e62c54ab37dcfcfb1f55774ba4222ef4eaa287a18e6bef429efa77f75617d8aR16-R31): Updated the name and icon for the `SavedSearchesPage` to "Saved GitHub Searches" and a new icon, respectively.

Addition of new search list items:

* [`GitHubExtension/Pages/SavedSearchesPage.cs`](diffhunk://#diff-8e62c54ab37dcfcfb1f55774ba4222ef4eaa287a18e6bef429efa77f75617d8aR16-R31): Added `addSearchListItem` and `addSearchFullFormListItem` with corresponding titles and icons for adding new searches.

Refactoring of item retrieval method:

* [`GitHubExtension/Pages/SavedSearchesPage.cs`](diffhunk://#diff-8e62c54ab37dcfcfb1f55774ba4222ef4eaa287a18e6bef429efa77f75617d8aR45): Refactored the `GetItems` method to use the newly added search list items and included subtitles for search pages. [[1]](diffhunk://#diff-8e62c54ab37dcfcfb1f55774ba4222ef4eaa287a18e6bef429efa77f75617d8aR45) [[2]](diffhunk://#diff-8e62c54ab37dcfcfb1f55774ba4222ef4eaa287a18e6bef429efa77f75617d8aL49-R69)

Removal of redundant methods:

* [`GitHubExtension/Pages/SavedSearchesPage.cs`](diffhunk://#diff-8e62c54ab37dcfcfb1f55774ba4222ef4eaa287a18e6bef429efa77f75617d8aL92-L96): Removed the `OnSearchSaving` method as it is no longer needed.