### PR TITLE
Prevent NullReferenceException in PendingRefreshState

### DIFF
--- a/GitHubExtension/DataManager/CacheManagerStates/PendingRefreshState.cs
+++ b/GitHubExtension/DataManager/CacheManagerStates/PendingRefreshState.cs
@@ -44,7 +44,7 @@ public class PendingRefreshState : CacheManagerState
         switch (e.Kind)
         {
             case DataManagerUpdateKind.Cancel:
-                Logger.Information($"Received data manager cancellation. Refreshing for {CacheManager.PendingSearch!.Name}");
+                Logger.Information($"Received data manager cancellation. Refreshing for {CacheManager.PendingSearch?.Name}");
                 lock (CacheManager.GetStateLock())
                 {
                     CacheManager.SetState(CacheManager.RefreshingState);


### PR DESCRIPTION
Before:
- If you switched pages too quickly, you would either seeing an infinite loading PR search page or get an empty state saying an error occurred.

What was going on:
- Previously, line 47 was `Logger.Information($"Received data manager cancellation. Refreshing for {CacheManager.PendingSearch!.Name}");` While the null-forgiving operator (!) suppressed the compiler error that a null reference exception could occur here, it didn't prevent the compiler from trying to access `CacheManager.PendingSearch.Name`, even if `CacheManager.PendingSearch` was null. Switching the null-forgiving operator (!) for the null-conditional operator (?) prevents this exception from occurring.

This seems like a safe fix because for `UpdateType.PullRequests` and `UpdateType.Issues` don't require a non-null search object, just `UpdateType.All` and `UpdateType.Search`. We may need to add more specific null-checking if this line was intended to catch null searches before calling the `CacheManager`.

After:
- The UI is no longer hung on this error