### PR TITLE
Add default searches upon login

### DIFF
--- a/GitHubExtension/GitHubExtensionCommandsProvider.cs
+++ b/GitHubExtension/GitHubExtensionCommandsProvider.cs
@@ -133,8 +133,11 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider
 
             foreach (var search in defaultSearches)
             {
-                _persistentDataManager.ValidateSearch(search);
-                _persistentDataManager.UpdateSearchTopLevelStatus(search, true);
+                _ = Task.Run(async () =>
+                {
+                    await _persistentDataManager.ValidateSearch(search);
+                    await _persistentDataManager.UpdateSearchTopLevelStatus(search, true);
+                });
             }
         }
 


### PR DESCRIPTION
This PR adds default searches upon login

These include:
- Assigned to Me: state:open assignee:{login} archived:false 
- Review Requested: state:open is:pr review-requested: {login} archived:false 
- Mentions Me: state:open mentions: {login} archived:false
- Created issues: state:open is:issue author: {login} archived:false 
- My PRs: state:open is:pr author:{login} archived:false

Notes:
- Users can edit, remove, or unpin these commands from the top-level
- These will appear whenever a user logs in (including if they log out, then log back in again with the same or different credentials)
- Because this implementation adds the default searches to `PersistentManager`'s saved searches, no tests needed to be modified
