### PR TITLE
Add a title and icon to SaveSearchPage

### DIFF
--- a/GitHubExtension/Controls/Pages/SaveSearchPage.cs
+++ b/GitHubExtension/Controls/Pages/SaveSearchPage.cs
@@ -17,14 +17,14 @@ public sealed partial class SaveSearchPage : ContentPage
     private readonly string _successMessage;
     private readonly string _errorMessage;
 
-    public SaveSearchPage(SaveSearchForm saveSearchForm, StatusMessage statusMessage, string successMessage, string errorMessage, IResources resources)
+    public SaveSearchPage(SaveSearchForm saveSearchForm, StatusMessage statusMessage, string successMessage, string errorMessage, string saveSearchPageTitle)
     {
         _saveSearchForm = saveSearchForm;
         _statusMessage = statusMessage;
         _successMessage = successMessage;
         _errorMessage = errorMessage;
         Icon = new IconInfo("\uecc8");
-        Title = resources.GetResource("ListItems_AddSearch");
+        Title = saveSearchPageTitle;
 
         // Wire up events using the helper
         FormEventHelper.WireFormEvents(_saveSearchForm, this, _statusMessage, _successMessage, _errorMessage);

--- a/GitHubExtension/Program.cs
+++ b/GitHubExtension/Program.cs
@@ -131,7 +131,7 @@ public class Program
 
         var searchPageFactory = new SearchPageFactory(cacheDataManager, searchRepository, resources);
 
-        var addSearchListItem = new AddSearchListItem(new SaveSearchPage(new SaveSearchForm(searchRepository, resources), new StatusMessage(), resources.GetResource("Message_Search_Saved"), resources.GetResource("Message_Search_Saved_Error"), resources), resources);
+        var addSearchListItem = new AddSearchListItem(new SaveSearchPage(new SaveSearchForm(searchRepository, resources), new StatusMessage(), resources.GetResource("Message_Search_Saved"), resources.GetResource("Message_Search_Saved_Error"), resources.GetResource("ListItems_AddSearch")), resources);
 
         var savedSearchesPage = new SavedSearchesPage(searchPageFactory, searchRepository, resources, addSearchListItem);
 


### PR DESCRIPTION
Closes #128 

Before:
- Add a search form (and its list item) in SaveSearchForm, had an icon and title, but the SaveSearchPage did not.
- As a result, when the page was opened, there wouldn't be an icon or title in the Command Palette UI

After:
![image](https://github.com/user-attachments/assets/4353c971-74bd-473d-9953-5f79495e8a7b)
