### PR TITLE
Update resource strings in SaveSearchForm

### DIFF
--- a/GitHubExtension/Controls/Forms/SaveSearchForm.cs
+++ b/GitHubExtension/Controls/Forms/SaveSearchForm.cs
@@ -34,12 +34,12 @@ public sealed partial class SaveSearchForm : FormContent, IGitHubForm
         { "{{SavedSearchString}}", _savedSearch.SearchString },
         { "{{SavedSearchName}}", _savedSearch.Name },
         { "{{IsTopLevel}}", IsTopLevelChecked },
-        { "{{EnteredSearchErrorMessage}}", _resources.GetResource("SaveSearchTemplateEnteredSearchError") },
-        { "{{EnteredSearchLabel}}", _resources.GetResource("SaveSearchTemplateEnteredSearchLabel") },
-        { "{{NameLabel}}", _resources.GetResource("SaveSearchTemplateNameLabel") },
-        { "{{NameErrorMessage}}", _resources.GetResource("SaveSearchTemplateNameError") },
-        { "{{IsTopLevelTitle}}", _resources.GetResource("SaveSearchTemplateIsTopLevelTitle") },
-        { "{{SaveSearchActionTitle}}", _resources.GetResource("SaveSearchTemplateSaveSearchActionTitle") },
+        { "{{EnteredSearchErrorMessage}}", _resources.GetResource("Forms_SaveSearchTemplateEnteredSearchError") },
+        { "{{EnteredSearchLabel}}", _resources.GetResource("Forms_SaveSearchTemplateEnteredSearchLabel") },
+        { "{{NameLabel}}", _resources.GetResource("Forms_SaveSearchTemplateNameLabel") },
+        { "{{NameErrorMessage}}", _resources.GetResource("Forms_SaveSearchTemplateNameError") },
+        { "{{IsTopLevelTitle}}", _resources.GetResource("Forms_SaveSearchTemplateIsTopLevelTitle") },
+        { "{{SaveSearchActionTitle}}", _resources.GetResource("Forms_SaveSearchTemplateSaveSearchActionTitle") },
     };
 
     // for saving a new query


### PR DESCRIPTION
Before:
- The resource strings for SaveSearchForm were updated with the prefix "Forms_*", but the strings in _resources.GetResources() calls weren't, so the strings were appearing in the Save Query page and the Edit Query page

After:
- The _resources.GetResources() strings were updated, so the strings are appearing properly in the Save Query and Edit Query pages