### PR TITLE
Add more error handling to the CommandsProvider

### DIFF
--- a/GitHubExtension/GitHubExtensionCommandsProvider.cs
+++ b/GitHubExtension/GitHubExtensionCommandsProvider.cs
@@ -145,7 +145,21 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"Failed to update top-level searches: {ex}");
+                var message = $"{_resources.GetResource("CommandsProvider_DefaultCommands_Error")}: {ex.Message}";
+                Debug.WriteLine(message);
+                if (ex is Octokit.ApiException)
+                {
+                    Octokit.ApiException apiException = (Octokit.ApiException)ex;
+                    message += $" - {StringHelper.ParseHttpErrorMessage(apiException.HttpResponse?.Body?.ToString())}";
+                }
+
+                ExtensionHost.LogMessage(new LogMessage() { Message = ex.Message });
+                var statusMessage = new StatusMessage
+                {
+                    Message = message,
+                    State = MessageState.Error,
+                };
+                ExtensionHost.ShowStatus(statusMessage, StatusContext.Page);
             }
         }
 

--- a/GitHubExtension/GitHubExtensionCommandsProvider.cs
+++ b/GitHubExtension/GitHubExtensionCommandsProvider.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using GitHubExtension.Controls;
 using GitHubExtension.Controls.Commands;
 using GitHubExtension.Controls.Forms;
@@ -135,9 +136,16 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider
                 new SearchCandidate($"is:open is:pr author:{login} archived:false sort:created-desc", _resources.GetResource("CommandsProvider_MyPullRequestsCommandName")),
             };
 
-            foreach (var search in defaultSearches)
+            try
             {
-                await _persistentDataManager.UpdateSearchTopLevelStatus(search, true);
+                foreach (var search in defaultSearches)
+                {
+                    await _persistentDataManager.UpdateSearchTopLevelStatus(search, true);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Failed to update top-level searches: {ex}");
             }
         }
 

--- a/GitHubExtension/Strings/en-US/Resources.resw
+++ b/GitHubExtension/Strings/en-US/Resources.resw
@@ -353,4 +353,8 @@
     <value>The GitHub extension for Windows Command Palette.</value>
     <comment>Description for extension package</comment>
   </data>
+  <data name="CommandsProvider_DefaultCommands_Error" xml:space="preserve">
+    <value>Adding a query to the top level failed</value>
+    <comment>The error message displayed if adding the default commands to the top level fails</comment>
+  </data>
 </root>


### PR DESCRIPTION
Before:
- Default tasks were added through Tasks, which propagated errors. When we moved default task adding out of tasks, we lost the ability to contain and log errors.

After:
- This try/catch will let us handle validation errors in the Commands Provider without jeopardizing the extension's core functionality.