### PR TITLE
Improving Pipeline

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -68,8 +68,8 @@ extends:
                 - task: PowerShell@2
                   displayName: Building MSIX
                   inputs:
-                  filePath: './build/scripts/Build.ps1'
-                  arguments: -Platform "${{ platform }}" -Configuration "${{ configuration }}" -Version $(MSIXVersion)
+                    filePath: './build/scripts/Build.ps1'
+                    arguments: -Platform "${{ platform }}" -Configuration "${{ configuration }}" -Version $(MSIXVersion)
                 
                 - template: ./build/templates/EsrpSigning-Steps.yml@self
                   parameters:

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -65,29 +65,11 @@ extends:
                     filePath: './build/scripts/SetupBuildInfo.ps1'
                     arguments: -Version $(MSIXVersion) -IsAzurePipelineBuild
 
-                - task: MSBuild@1
-                  displayName: Restoring packages
-                  inputs:
-                    solution: '$(solution)'
-                    msbuildArchitecture: '${{ platform }}'
-                    platform: '${{ platform }}'
-                    configuration: '${{ configuration }}'
-                    msbuildArguments: '/t:Restore'
-
-                - task: MsixPackaging@1
+                - task: PowerShell@2
                   displayName: Building MSIX
                   inputs:
-                    outputPath: 'BuildOutput\GitHubExtension_${{ configuration }}_${{ platform }}.msix'
-                    solution: '$(solution)'
-                    clean: false
-                    generateBundle: false
-                    buildConfiguration: '${{ configuration }}'
-                    buildPlatform: '${{ platform }}'
-                    updateAppVersion: false
-                    appPackageDistributionMode: 'SideloadOnly'
-                    msbuildLocationMethod: 'version'
-                    msbuildVersion: 'latest'
-                    msbuildArchitecture: '${{ platform }}'
+                  filePath: './build/scripts/Build.ps1'
+                  arguments: -Platform "${{ platform }}" -Configuration "${{ configuration }}" -Version $(MSIXVersion)
                 
                 - template: ./build/templates/EsrpSigning-Steps.yml@self
                   parameters:
@@ -131,7 +113,7 @@ extends:
                         
                 - task: PowerShell@2
                   displayName: 'Run Unittests'
-                  condition: ne('${{ platform}}', 'arm64')
+                  condition: ne('${{ platform }}', 'arm64')
                   retryCountOnTaskFailure: 2
                   inputs:
                     filePath: 'build/scripts/Test.ps1'


### PR DESCRIPTION
- This change adds the version number to the msix filename, so it gets clearer to the users which version they are getting.
- We are also changing the `Test.ps1` to run all the tests that are not marked as `LiveData`, so we don't need to mark everything as `Unit` for the test to be run.
- This PR also removes UI testing logic from `Test.ps1`, as we are not using it on our extension and don't plan to use it in the foreseeable future.
- This also changes some logic on `Build.ps1` so we can in the future change the Azure pipeline to use it instead of the standard pipeline tasks, giving us more control of how it builds and also giving users the option of building the project locally using the script.

