### PR TITLE
Enable/disable sign in button

### DIFF
--- a/GitHubExtension.Test/DeveloperIdTests/OAuthRequestTest.cs
+++ b/GitHubExtension.Test/DeveloperIdTests/OAuthRequestTest.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.DeveloperId;
+using Moq;
+using Octokit;
+
+namespace GitHubExtension.Test.DeveloperIdTests;
+
+[TestClass]
+public class OAuthRequestTest
+{
+    [TestMethod]
+    public async Task CompleteOAuthAsync_ShouldThrowInvalidOperationException_OnTimeout()
+    {
+        var mockGitHubClient = new Mock<IGitHubClient>();
+        var mockOauthClient = new Mock<IOauthClient>();
+
+        mockGitHubClient.Setup(client => client.Oauth).Returns(mockOauthClient.Object);
+
+        mockOauthClient
+            .Setup(oauth => oauth.CreateAccessToken(It.IsAny<OauthTokenRequest>()))
+            .Returns(async () =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(10));
+                return new OauthToken();
+            });
+
+        var oAuthRequest = new OAuthRequest();
+
+        var authorizationResponse = new Uri("https://example.com/callback?code=valid_code");
+
+        await Assert.ThrowsExceptionAsync<InvalidOperationException>(async () =>
+        {
+            await oAuthRequest.CompleteOAuthAsync(authorizationResponse);
+        });
+    }
+}

--- a/GitHubExtension/Controls/Forms/SignInForm.cs
+++ b/GitHubExtension/Controls/Forms/SignInForm.cs
@@ -35,7 +35,12 @@ public partial class SignInForm : FormContent, IGitHubForm
 
     private void DeveloperIdProvider_OAuthRedirected(object? sender, Uri e)
     {
-        _isButtonEnabled = false;
+        SetButtonEnabled(false);
+    }
+
+    public void SetButtonEnabled(bool isEnabled)
+    {
+        _isButtonEnabled = isEnabled;
         TemplateJson = TemplateHelper.LoadTemplateJsonFromTemplateName("AuthTemplate", TemplateSubstitutions);
         OnPropertyChanged(nameof(TemplateJson));
     }
@@ -66,6 +71,7 @@ public partial class SignInForm : FormContent, IGitHubForm
             catch (Exception ex)
             {
                 LoadingStateChanged?.Invoke(this, false);
+                SetButtonEnabled(true);
                 SignInAction?.Invoke(this, new SignInStatusChangedEventArgs(false, ex));
                 FormSubmitted?.Invoke(this, new FormSubmitEventArgs(false, ex));
             }

--- a/GitHubExtension/Controls/Forms/SignInForm.cs
+++ b/GitHubExtension/Controls/Forms/SignInForm.cs
@@ -33,8 +33,16 @@ public partial class SignInForm : FormContent, IGitHubForm
         _developerIdProvider.OAuthRedirected += DeveloperIdProvider_OAuthRedirected;
     }
 
-    private void DeveloperIdProvider_OAuthRedirected(object? sender, Uri e)
+    private void DeveloperIdProvider_OAuthRedirected(object? sender, Exception? e)
     {
+        if (e is not null)
+        {
+            SetButtonEnabled(true);
+            LoadingStateChanged?.Invoke(this, false);
+            SignInAction?.Invoke(this, new SignInStatusChangedEventArgs(false, e));
+            FormSubmitted?.Invoke(this, new FormSubmitEventArgs(false, e));
+        }
+
         SetButtonEnabled(false);
     }
 

--- a/GitHubExtension/Controls/Forms/SignOutForm.cs
+++ b/GitHubExtension/Controls/Forms/SignOutForm.cs
@@ -32,6 +32,7 @@ public sealed partial class SignOutForm : FormContent, IGitHubForm
         { "{{AuthButtonTitle}}", _resources.GetResource("Forms_Sign_Out_Button_Title") },
         { "{{AuthIcon}}", $"data:image/png;base64,{GitHubIcon.GetBase64Icon("logo")}" },
         { "{{AuthButtonTooltip}}", _resources.GetResource("Forms_Sign_Out_Tooltip") },
+        { "{{ButtonIsEnabled}}", "true" },
     };
 
     public override string TemplateJson => TemplateHelper.LoadTemplateJsonFromTemplateName("AuthTemplate", TemplateSubstitutions);

--- a/GitHubExtension/Controls/Pages/SignInPage.cs
+++ b/GitHubExtension/Controls/Pages/SignInPage.cs
@@ -6,6 +6,7 @@ using GitHubExtension.Controls.Forms;
 using GitHubExtension.Helpers;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
+using Windows.Foundation;
 
 namespace GitHubExtension.Controls.Pages;
 
@@ -26,8 +27,15 @@ public partial class SignInPage : ContentPage
         // Wire up events using the helper
         FormEventHelper.WireFormEvents(_signInForm, this, _statusMessage, _successMessage, _errorMessage);
 
+        _signInForm.PropChanged += UpdatePage;
+
         // Hide status message initially
         ExtensionHost.HideStatus(_statusMessage);
+    }
+
+    private void UpdatePage(object sender, IPropChangedEventArgs args)
+    {
+        RaiseItemsChanged();
     }
 
     public override IContent[] GetContent()

--- a/GitHubExtension/Controls/Templates/AuthTemplate.json
+++ b/GitHubExtension/Controls/Templates/AuthTemplate.json
@@ -1,7 +1,7 @@
 {
   "type": "AdaptiveCard",
   "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-  "version": "1.5",
+  "version": "1.6",
   "body": [
     {
       "type": "Container",
@@ -37,9 +37,10 @@
                   "type": "ActionSet",
                   "actions": [
                     {
-                      "type": "Action.Submit",
                       "title": "{{AuthButtonTitle}}",
-                      "tooltip": "{{AuthButtonTooltip}}"
+                      "tooltip": "{{AuthButtonTooltip}}",
+                      "type": "Action.Submit",
+                      "isEnabled": {{ButtonIsEnabled}}
                     }
                   ]
                 }

--- a/GitHubExtension/DeveloperId/DeveloperIdProvider.cs
+++ b/GitHubExtension/DeveloperId/DeveloperIdProvider.cs
@@ -38,6 +38,8 @@ public class DeveloperIdProvider : IDeveloperIdProvider
 
     private readonly Lazy<CredentialVault> _credentialVault;
 
+    public event EventHandler<Uri>? OAuthRedirected;
+
     // Private constructor for Singleton class.
     public DeveloperIdProvider()
     {
@@ -148,6 +150,8 @@ public class DeveloperIdProvider : IDeveloperIdProvider
     public void HandleOauthRedirection(Uri authorizationResponse)
     {
         OAuthRequest? oAuthRequest = null;
+
+        OAuthRedirected?.Invoke(this, authorizationResponse);
 
         lock (_oAuthRequestsLock)
         {

--- a/GitHubExtension/DeveloperId/DeveloperIdProvider.cs
+++ b/GitHubExtension/DeveloperId/DeveloperIdProvider.cs
@@ -38,7 +38,7 @@ public class DeveloperIdProvider : IDeveloperIdProvider
 
     private readonly Lazy<CredentialVault> _credentialVault;
 
-    public event EventHandler<Uri>? OAuthRedirected;
+    public event EventHandler<Exception?>? OAuthRedirected;
 
     // Private constructor for Singleton class.
     public DeveloperIdProvider()
@@ -151,7 +151,7 @@ public class DeveloperIdProvider : IDeveloperIdProvider
     {
         OAuthRequest? oAuthRequest = null;
 
-        OAuthRedirected?.Invoke(this, authorizationResponse);
+        OAuthRedirected?.Invoke(this, null);
 
         lock (_oAuthRequestsLock)
         {
@@ -185,7 +185,15 @@ public class DeveloperIdProvider : IDeveloperIdProvider
             }
         }
 
-        oAuthRequest.CompleteOAuthAsync(authorizationResponse).Wait();
+        try
+        {
+           oAuthRequest.CompleteOAuthAsync(authorizationResponse).Wait();
+        }
+        catch (Exception ex)
+        {
+           _log.Error(ex, $"Error while completing OAuth request: ");
+           OAuthRedirected?.Invoke(this, ex);
+        }
     }
 
     public IEnumerable<IDeveloperId> GetLoggedInDeveloperIdsInternal()

--- a/GitHubExtension/DeveloperId/IDeveloperIdProvider.cs
+++ b/GitHubExtension/DeveloperId/IDeveloperIdProvider.cs
@@ -17,4 +17,6 @@ public interface IDeveloperIdProvider
     bool LogoutDeveloperId(IDeveloperId developerId);
 
     void HandleOauthRedirection(Uri authorizationResponse);
+
+    public event EventHandler<Uri>? OAuthRedirected;
 }

--- a/GitHubExtension/DeveloperId/IDeveloperIdProvider.cs
+++ b/GitHubExtension/DeveloperId/IDeveloperIdProvider.cs
@@ -18,5 +18,5 @@ public interface IDeveloperIdProvider
 
     void HandleOauthRedirection(Uri authorizationResponse);
 
-    public event EventHandler<Uri>? OAuthRedirected;
+    public event EventHandler<Exception?>? OAuthRedirected;
 }


### PR DESCRIPTION
Before:
- When a user clicks on the sign in button and signs in, the button remains enabled even as github.com redirects back to the extension. This means the user could initiate multiple requests with multiple redirect options, which is not a good user experience

After:
- Now, when a user clicks on the sign in button and signs in, the sign in button is disabled when github.com redirects back.
- Errors in the OAuth redirection flow are now displayed to the user