### PR TITLE
Properly close extension

### DIFF
--- a/GitHubExtension/Program.cs
+++ b/GitHubExtension/Program.cs
@@ -171,6 +171,8 @@ public class Program
         // This will make the main thread wait until the event is signalled by the extension class.
         // Since we have single instance of the extension object, we exit as soon as it is disposed.
         extensionDisposedEvent.WaitOne();
+        server.Stop();
+        server.UnsafeDispose();
     }
 
     private static void HandleExtensionInstanceRelease(object? sender, ManualResetEvent e) => DecompositionRoot(_disposables!, e);


### PR DESCRIPTION
Properly close the extension when CmdPal is closed (porting of https://github.com/microsoft/PowerToys/pull/39209)
Note that https://github.com/microsoft/PowerToys/pull/39589 is needed in order to properly close extensions when CmdPal is closed from PowerToys system tray.

Validation steps:
- Launch CmdPal
- Verify that `GitHubExtension` process is running
- Invoke CmdPal
- Press Alt+F4
- Verify that `GitHubExtension` process is closed