### PR TITLE
Make button titles more descriptive

### DIFF
--- a/GitHubExtension/Controls/Forms/SaveSearchForm.cs
+++ b/GitHubExtension/Controls/Forms/SaveSearchForm.cs
@@ -39,7 +39,7 @@ public sealed partial class SaveSearchForm : FormContent, IGitHubForm
         { "{{NameLabel}}", _resources.GetResource("Forms_SaveSearchTemplateNameLabel") },
         { "{{NameErrorMessage}}", _resources.GetResource("Forms_SaveSearchTemplateNameError") },
         { "{{IsTopLevelTitle}}", _resources.GetResource("Forms_SaveSearchTemplateIsTopLevelTitle") },
-        { "{{SaveSearchActionTitle}}", _resources.GetResource("Forms_SaveSearchTemplateSaveSearchActionTitle") },
+        { "{{SaveSearchActionTitle}}", _resources.GetResource(string.IsNullOrEmpty(_savedSearch.Name) ? "Forms_SaveSearchTemplateSaveSearchActionTitle" : "Forms_SaveSearchTemplateEditSearchActionTitle") },
     };
 
     // for saving a new query

--- a/GitHubExtension/Controls/Forms/SaveSearchForm.cs
+++ b/GitHubExtension/Controls/Forms/SaveSearchForm.cs
@@ -30,7 +30,7 @@ public sealed partial class SaveSearchForm : FormContent, IGitHubForm
 
     public Dictionary<string, string> TemplateSubstitutions => new()
     {
-        { "{{SaveSearchFormTitle}}", _resources.GetResource(string.IsNullOrEmpty(_savedSearch.Name) ? "Forms_Save_Search" : "Forms_Edit_Search") },
+        { "{{SaveSearchFormTitle}}", _resources.GetResource(string.IsNullOrWhiteSpace(_savedSearch.Name) ? "Forms_Save_Search" : "Forms_Edit_Search") },
         { "{{SavedSearchString}}", _savedSearch.SearchString },
         { "{{SavedSearchName}}", _savedSearch.Name },
         { "{{IsTopLevel}}", IsTopLevelChecked },
@@ -39,7 +39,7 @@ public sealed partial class SaveSearchForm : FormContent, IGitHubForm
         { "{{NameLabel}}", _resources.GetResource("Forms_SaveSearchTemplateNameLabel") },
         { "{{NameErrorMessage}}", _resources.GetResource("Forms_SaveSearchTemplateNameError") },
         { "{{IsTopLevelTitle}}", _resources.GetResource("Forms_SaveSearchTemplateIsTopLevelTitle") },
-        { "{{SaveSearchActionTitle}}", _resources.GetResource(string.IsNullOrEmpty(_savedSearch.Name) ? "Forms_SaveSearchTemplateSaveSearchActionTitle" : "Forms_SaveSearchTemplateEditSearchActionTitle") },
+        { "{{SaveSearchActionTitle}}", _resources.GetResource(string.IsNullOrWhiteSpace(_savedSearch.Name) ? "Forms_SaveSearchTemplateSaveSearchActionTitle" : "Forms_SaveSearchTemplateEditSearchActionTitle") },
     };
 
     // for saving a new query
@@ -78,7 +78,7 @@ public sealed partial class SaveSearchForm : FormContent, IGitHubForm
     {
         try
         {
-            if (string.IsNullOrEmpty(payload))
+            if (string.IsNullOrWhiteSpace(payload))
             {
                 return new SearchCandidate();
             }
@@ -129,7 +129,8 @@ public sealed partial class SaveSearchForm : FormContent, IGitHubForm
             searchFromUrl = SearchHelper.ParseSearchStringFromUri(uri);
         }
 
-        searchStr = string.IsNullOrEmpty(searchFromUrl) ? enteredSearch : searchFromUrl;
+        searchStr = string.IsNullOrWhiteSpace(searchFromUrl) ? enteredSearch : searchFromUrl;
+        name = string.IsNullOrWhiteSpace(name) ? searchStr : name;
 
         return new SearchCandidate(searchStr, name, isTopLevel);
     }

--- a/GitHubExtension/Controls/Pages/IssueMarkdownPage.cs
+++ b/GitHubExtension/Controls/Pages/IssueMarkdownPage.cs
@@ -25,9 +25,9 @@ internal sealed partial class IssueContentPage : ContentPage
         Commands = new CommandContextItem[]
         {
             new(new LinkCommand(issue, resources)),
-            new(new CopyCommand(issue.HtmlUrl, _resources.GetResource("Pages_Item_URL"))),
-            new(new CopyCommand(issue.Title, _resources.GetResource("Pages_Issue_Title"))),
-            new(new CopyCommand(issue.Number.ToString(CultureInfo.InvariantCulture), _resources.GetResource("Pages_Issue_Number"))),
+            new(new CopyCommand(issue.HtmlUrl, _resources.GetResource("Commands_CopyURL"))),
+            new(new CopyCommand(issue.Title, _resources.GetResource("Commands_CopyIssueTitle"))),
+            new(new CopyCommand(issue.Number.ToString(CultureInfo.InvariantCulture), _resources.GetResource("Commands_CopyIssueNumber"))),
         };
 #pragma warning restore IDE0300 // Simplify collection initialization
     }

--- a/GitHubExtension/Controls/Pages/PullRequestMarkdownPage.cs
+++ b/GitHubExtension/Controls/Pages/PullRequestMarkdownPage.cs
@@ -26,9 +26,9 @@ internal sealed partial class PullRequestContentPage : ContentPage
         Commands = new CommandContextItem[]
         {
             new(new LinkCommand(pullRequest, resources)),
-            new(new CopyCommand(pullRequest.HtmlUrl, _resources.GetResource("Pages_Item_URL"))),
-            new(new CopyCommand(pullRequest.Title, _resources.GetResource("Pages_PullRequest_Title"))),
-            new(new CopyCommand(pullRequest.Number.ToString(CultureInfo.InvariantCulture), _resources.GetResource("Pages_PullRequest_Number"))),
+            new(new CopyCommand(pullRequest.HtmlUrl, _resources.GetResource("Commands_CopyURL"))),
+            new(new CopyCommand(pullRequest.Title, _resources.GetResource("Commands_CopyPullRequestTitle"))),
+            new(new CopyCommand(pullRequest.Number.ToString(CultureInfo.InvariantCulture), _resources.GetResource("Commands_CopyPullRequestNumber"))),
         };
 #pragma warning restore IDE0300 // Simplify collection initialization
     }

--- a/GitHubExtension/Controls/Pages/SearchPages/IssuesSearchPage.cs
+++ b/GitHubExtension/Controls/Pages/SearchPages/IssuesSearchPage.cs
@@ -23,7 +23,7 @@ public sealed partial class IssuesSearchPage(ISearch search, ICacheDataManager c
             {
                 new(new CopyCommand(item.HtmlUrl, $"{Resources.GetResource("Commands_CopyURL")}")),
                 new(new CopyCommand(item.Title, $"{Resources.GetResource("Commands_CopyIssueTitle")}")),
-                new(new CopyCommand(item.Number.ToString(CultureInfo.InvariantCulture), $"{Resources.GetResource("Commands_CopyIssue_Number")}")),
+                new(new CopyCommand(item.Number.ToString(CultureInfo.InvariantCulture), $"{Resources.GetResource("Commands_CopyIssueNumber")}")),
                 new(new IssueContentPage(item, Resources)),
             },
             Tags = GetTags(item),

--- a/GitHubExtension/Strings/en-US/Resources.resw
+++ b/GitHubExtension/Strings/en-US/Resources.resw
@@ -373,4 +373,8 @@
     <value>Copy pull request title</value>
     <comment>The name of the copy pull request title command</comment>
   </data>
+  <data name="Forms_SaveSearchTemplateEditSearchActionTitle" xml:space="preserve">
+    <value>Save edited query</value>
+    <comment>The title for the button that submits the form in the EditSearchPage</comment>
+  </data>
 </root>

--- a/GitHubExtension/Strings/en-US/Resources.resw
+++ b/GitHubExtension/Strings/en-US/Resources.resw
@@ -134,7 +134,7 @@
     <comment>Title for command to open an item in the browser</comment>
   </data>
   <data name="Commands_Remove_Saved_Search" xml:space="preserve">
-    <value>Remove</value>
+    <value>Remove saved search</value>
     <comment>Title for command to remove a saved query</comment>
   </data>
   <data name="Forms_Save_Search" xml:space="preserve">
@@ -181,20 +181,12 @@
     <value>No items found</value>
     <comment>Body of error message when an error ocurred fetching items</comment>
   </data>
-  <data name="Pages_Issue_Title" xml:space="preserve">
-    <value>issue title</value>
-    <comment>Shown in command to copy issue title on pages</comment>
-  </data>
   <data name="Pages_PullRequest_Title" xml:space="preserve">
     <value>pull request title</value>
     <comment>Shown in command to copy title of pull request on a page</comment>
   </data>
-  <data name="Pages_Item_Number" xml:space="preserve">
-    <value>item number</value>
-    <comment>Shown in command to copy the number of a issue or pull request on a page</comment>
-  </data>
   <data name="Pages_Edit" xml:space="preserve">
-    <value>Edit</value>
+    <value>Edit query</value>
     <comment>Name and title for edit search page</comment>
   </data>
   <data name="Pages_Markdown_Issue" xml:space="preserve">
@@ -281,17 +273,9 @@
     <value>pull request number</value>
     <comment>Tooltip for command to copy pull request number</comment>
   </data>
-  <data name="Pages_Issue_Number" xml:space="preserve">
-    <value>issue number</value>
-    <comment>Tooltip for command to copy issue number</comment>
-  </data>
   <data name="Pages_PullRequest_SourceBranch" xml:space="preserve">
     <value>source branch</value>
     <comment>Tooltip for copy source branch command</comment>
-  </data>
-  <data name="Pages_Item_URL" xml:space="preserve">
-    <value>URL</value>
-    <comment>Tooltip for copying an issue or PR URL</comment>
   </data>
   <data name="Pages_PullRequest_Checkout" xml:space="preserve">
     <value>checkout command</value>
@@ -306,7 +290,7 @@
     <comment>Shown as the label for the input text box for the GitHub query</comment>
   </data>
   <data name="Forms_SaveSearchTemplateNameLabel" xml:space="preserve">
-    <value>Name</value>
+    <value>Query name</value>
     <comment>Shown as the name for the saved query</comment>
   </data>
   <data name="Forms_SaveSearchTemplateNameError" xml:space="preserve">
@@ -318,7 +302,7 @@
     <comment>The label text for the checkbox that determines if the query should be pinned as a top level command</comment>
   </data>
   <data name="Forms_SaveSearchTemplateSaveSearchActionTitle" xml:space="preserve">
-    <value>Save</value>
+    <value>Save query</value>
     <comment>The title for the button that submits the form and saves the query</comment>
   </data>
   <data name="CommandsProvider_AssignedToMeCommandName" xml:space="preserve">

--- a/README.md
+++ b/README.md
@@ -16,7 +16,20 @@ The Command Palette GitHub Extension requires:
 * Windows 11
 * An ARM64 or x64 processor
 
-### WinGet [Recommended]
+## Command Palette [Recommended]
+
+* In Command Palette, search for "Install Command Palette extensions" and press Enter.
+* Search for "Command Palette GitHub Extension (Preview)".
+* Press enter to download the extension.
+* Navigate back to the main screen. If the extension was able to detect your account automatically, you will see the following commands:
+    * Saved queries
+    * Assigned to me
+    * Created issues
+    * My pull requests
+    * Mentions me
+* Otherwise, you'll see a "Sign in" command. Click sign in to login via the GitHub OAuth flows.
+
+### WinGet
 
 More instructions coming soon!
 
@@ -28,7 +41,7 @@ The Command Palette GitHub Extension is coming to the Microsoft Store. Stay tune
 
 #### Via GitHub
 
-For users who are unable to install the Command Palette GitHub Extension from the Microsoft Store, released builds can be manually downloaded from this repository's [Releases page](https://github.com/microsoft/CmdPalGitHubExtension/releases).
+For users who are unable to install the Command Palette GitHub Extension from the winget or the Microsoft Store, released builds can be manually downloaded from this repository's [Releases page](https://github.com/microsoft/CmdPalGitHubExtension/releases).
 
 ---
 


### PR DESCRIPTION
Closes #241, #240

Before:
![image](https://github.com/user-attachments/assets/84b7760f-a6a0-4dbe-bd4d-1d982cebc17f)
![image](https://github.com/user-attachments/assets/a9bf093e-c16b-4b43-82df-d442c4ba1c42)

After:
![after_markdowncontextmenu](https://github.com/user-attachments/assets/48fbe8fa-9df6-4389-9f45-315464e58b58)
![after_savequery](https://github.com/user-attachments/assets/729b324f-5dd3-4a74-bc9a-148ad2f4f2de)
