### PR TITLE
Add user login to the sign out button

### DIFF
--- a/GitHubExtension.Test/Controls/SignInFormTest.cs
+++ b/GitHubExtension.Test/Controls/SignInFormTest.cs
@@ -2,7 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using GitHubExtension.DeveloperId;
+using GitHubExtension.DeveloperIds;
 using Moq;
 using Octokit;
 

--- a/GitHubExtension.Test/Controls/SignOutFormTests.cs
+++ b/GitHubExtension.Test/Controls/SignOutFormTests.cs
@@ -22,12 +22,13 @@ namespace GitHubExtension.Test.Controls;
 public class SignOutFormTests
 {
     private sealed record TestContext(
-        Mock<IResources> ResourcesMock,
-        Mock<SignOutCommand> SignOutCommandMock,
-        Mock<AuthenticationMediator> AuthMediatorMock,
-        Mock<IDeveloperIdProvider> DeveloperIdProviderMock,
-        SignOutForm Form
-    );
+    Mock<IResources> ResourcesMock,
+    Mock<SignOutCommand> SignOutCommandMock,
+    Mock<AuthenticationMediator> AuthMediatorMock,
+    Mock<IDeveloperIdProvider> DeveloperIdProviderMock,
+    SignOutForm Form,
+    string AssetsPath
+);
 
     private TestContext CreateTestContext(
         string? developerId = "user1",
@@ -63,7 +64,13 @@ public class SignOutFormTests
             mockSignOutCommand.Object,
             mockDeveloperIdProvider.Object);
 
-        return new TestContext(mockResources, mockSignOutCommand, mockAuthenticationMediator, mockDeveloperIdProvider, form);
+        // Dynamically resolve the path to the Assets folder
+        var assetsPath = Path.Combine(
+            AppContext.BaseDirectory,
+            "Assets");
+        assetsPath = Path.GetFullPath(assetsPath);
+
+        return new TestContext(mockResources, mockSignOutCommand, mockAuthenticationMediator, mockDeveloperIdProvider, form, assetsPath);
     }
 
     [TestMethod]

--- a/GitHubExtension.Test/Controls/SignOutFormTests.cs
+++ b/GitHubExtension.Test/Controls/SignOutFormTests.cs
@@ -166,8 +166,8 @@ public class SignOutFormTests
     {
         var ctx = CreateTestContext(resourceFunc: _ => null);
         var dict = ctx.Form.TemplateSubstitutions;
-        Assert.IsNull(dict["{{AuthTitle}}"]);
-        Assert.IsNull(dict["{{AuthButtonTooltip}}"]);
+        Assert.AreEqual(dict["{{AuthTitle}}"], "Forms_Sign_Out_Title");
+        Assert.AreEqual(dict["{{AuthButtonTooltip}}"], "Forms_Sign_Out_Tooltip");
     }
 
     [TestMethod]

--- a/GitHubExtension.Test/Controls/SignOutFormTests.cs
+++ b/GitHubExtension.Test/Controls/SignOutFormTests.cs
@@ -1,0 +1,186 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using GitHubExtension.Controls;
+using GitHubExtension.Controls.Commands;
+using GitHubExtension.Controls.Forms;
+using GitHubExtension.DeveloperIds;
+using GitHubExtension.Helpers;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Octokit;
+
+namespace GitHubExtension.Test.Controls;
+
+[TestClass]
+public class SignOutFormTests
+{
+    private sealed record TestContext(
+        Mock<IResources> ResourcesMock,
+        Mock<SignOutCommand> SignOutCommandMock,
+        Mock<AuthenticationMediator> AuthMediatorMock,
+        Mock<IDeveloperIdProvider> DeveloperIdProviderMock,
+        SignOutForm Form
+    );
+
+    private TestContext CreateTestContext(
+        string? developerId = "user1",
+        Func<string, string?>? resourceFunc = null)
+    {
+        var mockResources = new Mock<IResources>();
+        var mockAuthenticationMediator = new Mock<AuthenticationMediator>();
+        var mockDeveloperIdProvider = new Mock<IDeveloperIdProvider>();
+        var mockSignOutCommand = new Mock<SignOutCommand>(mockResources.Object, mockDeveloperIdProvider.Object, mockAuthenticationMediator.Object);
+
+        mockResources
+            .Setup(r => r.GetResource(It.IsAny<string>(), null))
+            .Returns((string key, Serilog.ILogger? _) => (resourceFunc != null ? resourceFunc(key) ?? key : $"res_{key}"));
+
+        if (developerId != null)
+        {
+            var devId = new DeveloperId(
+                developerId,
+                "Display Name",
+                "user1@example.com",
+                "https://github.com/user1",
+                new GitHubClient(new Octokit.ProductHeaderValue("TestApp")));
+            mockDeveloperIdProvider.Setup(d => d.GetLoggedInDeveloperId()).Returns(devId);
+        }
+        else
+        {
+            mockDeveloperIdProvider.Setup(d => d.GetLoggedInDeveloperId()).Returns((IDeveloperId?)null);
+        }
+
+        var form = new SignOutForm(
+            mockResources.Object,
+            mockAuthenticationMediator.Object,
+            mockSignOutCommand.Object,
+            mockDeveloperIdProvider.Object);
+
+        return new TestContext(mockResources, mockSignOutCommand, mockAuthenticationMediator, mockDeveloperIdProvider, form);
+    }
+
+    [TestMethod]
+    public void Constructor_RegistersEventHandlers()
+    {
+        // Just verify events exist (event handler registration is not directly testable without raising events)
+        var loadingStateChanged = typeof(AuthenticationMediator).GetEvent("LoadingStateChanged");
+        var signInAction = typeof(AuthenticationMediator).GetEvent("SignInAction");
+        var signOutAction = typeof(AuthenticationMediator).GetEvent("SignOutAction");
+
+        Assert.IsNotNull(loadingStateChanged);
+        Assert.IsNotNull(signInAction);
+        Assert.IsNotNull(signOutAction);
+    }
+
+    [TestMethod]
+    public void TemplateSubstitutions_ReturnsExpectedValues()
+    {
+        var ctx = CreateTestContext();
+        var dict = ctx.Form.TemplateSubstitutions;
+        Assert.AreEqual("res_Forms_Sign_Out_Title", dict["{{AuthTitle}}"]);
+        Assert.IsTrue(dict["{{AuthButtonTitle}}"].Contains("user1"));
+        Assert.IsTrue(dict["{{AuthIcon}}"].StartsWith("data:image/png;base64,", StringComparison.Ordinal));
+        Assert.AreEqual("res_Forms_Sign_Out_Tooltip", dict["{{AuthButtonTooltip}}"]);
+        Assert.AreEqual("true", dict["{{ButtonIsEnabled}}"]);
+    }
+
+    [TestMethod]
+    public void TemplateJson_ReturnsExpectedTemplate()
+    {
+        var ctx = CreateTestContext();
+        var json = ctx.Form.TemplateJson;
+        Assert.IsNotNull(json);
+        Assert.IsTrue(json.Length > 0);
+    }
+
+    [TestMethod]
+    public void SubmitForm_InvokesSignOutCommand()
+    {
+        var ctx = CreateTestContext();
+        ctx.SignOutCommandMock.Setup(c => c.Invoke()).Returns(Mock.Of<CommandResult>());
+
+        var result = ctx.Form.SubmitForm("inputs", "data");
+
+        ctx.SignOutCommandMock.Verify(c => c.Invoke(), Times.Once);
+        Assert.IsNotNull(result);
+    }
+
+    [TestMethod]
+    public void SetButtonEnabled_UpdatesButtonState()
+    {
+        var ctx = CreateTestContext();
+        var method = typeof(SignOutForm).GetMethod("SetButtonEnabled", BindingFlags.NonPublic | BindingFlags.Instance);
+        method!.Invoke(ctx.Form, new object[] { false });
+
+        var dict = ctx.Form.TemplateSubstitutions;
+        Assert.AreEqual("false", dict["{{ButtonIsEnabled}}"]);
+    }
+
+    [TestMethod]
+    public void ResetButton_UpdatesButtonState_OnSignInStatusChanged()
+    {
+        var ctx = CreateTestContext();
+        var method = typeof(SignOutForm).GetMethod("ResetButton", BindingFlags.NonPublic | BindingFlags.Instance);
+        var args = new SignInStatusChangedEventArgs(false);
+        method!.Invoke(ctx.Form, new object?[] { null, args });
+
+        var dict = ctx.Form.TemplateSubstitutions;
+        Assert.AreEqual("false", dict["{{ButtonIsEnabled}}"]);
+    }
+
+    [TestMethod]
+    public void OnLoadingStateChanged_DisablesButton()
+    {
+        var ctx = CreateTestContext();
+        var method = typeof(SignOutForm).GetMethod("OnLoadingStateChanged", BindingFlags.NonPublic | BindingFlags.Instance);
+        method!.Invoke(ctx.Form, new object[] { new(), true });
+
+        var dict = ctx.Form.TemplateSubstitutions;
+        Assert.AreEqual("false", dict["{{ButtonIsEnabled}}"]);
+    }
+
+    [TestMethod]
+    public void TemplateSubstitutions_HandlesNullDeveloperId()
+    {
+        var ctx = CreateTestContext(developerId: null);
+        var dict = ctx.Form.TemplateSubstitutions;
+        Assert.IsFalse(dict["{{AuthButtonTitle}}"].Contains("null"));
+    }
+
+    [TestMethod]
+    public void TemplateSubstitutions_HandlesResourceLookupFailure()
+    {
+        var ctx = CreateTestContext(resourceFunc: _ => null);
+        var dict = ctx.Form.TemplateSubstitutions;
+        Assert.IsNull(dict["{{AuthTitle}}"]);
+        Assert.IsNull(dict["{{AuthButtonTooltip}}"]);
+    }
+
+    [TestMethod]
+    public void SetButtonEnabled_UpdatesTemplateJsonAndNotifiesPropertyChanged()
+    {
+        var ctx = CreateTestContext();
+
+        var oldTemplateJson = ctx.Form.TemplateJson;
+        var propertyChangedCalled = false;
+
+        var method = typeof(SignOutForm).GetMethod("SetButtonEnabled", BindingFlags.NonPublic | BindingFlags.Instance);
+        method!.Invoke(ctx.Form, new object[] { false });
+
+        var newTemplateJson = ctx.Form.TemplateJson;
+        if (!Equals(oldTemplateJson, newTemplateJson))
+        {
+            propertyChangedCalled = true;
+        }
+
+        Assert.IsTrue(propertyChangedCalled);
+        Assert.IsNotNull(ctx.Form.TemplateJson);
+    }
+}

--- a/GitHubExtension.Test/Controls/TopLevelSearchesTest.cs
+++ b/GitHubExtension.Test/Controls/TopLevelSearchesTest.cs
@@ -468,7 +468,7 @@ public class TopLevelSearchesTest
         var mockAuthenticationMediator = new Mock<AuthenticationMediator>().Object;
         var mockSignOutCommand = new Mock<SignOutCommand>(mockResources, mockDeveloperIdProvider, mockAuthenticationMediator).Object;
         var mockSignInCommand = new Mock<SignInCommand>(mockResources, mockDeveloperIdProvider, mockAuthenticationMediator).Object;
-        var mockSignOutForm = new Mock<SignOutForm>(mockResources, mockAuthenticationMediator, mockSignOutCommand).Object;
+        var mockSignOutForm = new Mock<SignOutForm>(mockResources, mockAuthenticationMediator, mockSignOutCommand, mockDeveloperIdProvider).Object;
         var mockSignInForm = new Mock<SignInForm>(mockAuthenticationMediator, mockResources, mockDeveloperIdProvider, mockSignInCommand).Object;
         var signOutPage = new SignOutPage(mockResources, mockSignOutForm, mockSignOutCommand, mockAuthenticationMediator);
         var signInPage = new SignInPage(mockSignInForm, mockResources, mockSignInCommand, mockAuthenticationMediator);

--- a/GitHubExtension.Test/Controls/TopLevelSearchesTest.cs
+++ b/GitHubExtension.Test/Controls/TopLevelSearchesTest.cs
@@ -8,7 +8,7 @@ using GitHubExtension.Controls.Commands;
 using GitHubExtension.Controls.Forms;
 using GitHubExtension.Controls.Pages;
 using GitHubExtension.DataModel;
-using GitHubExtension.DeveloperId;
+using GitHubExtension.DeveloperIds;
 using GitHubExtension.Helpers;
 using GitHubExtension.PersistentData;
 using GitHubExtension.Test.PersistentData;

--- a/GitHubExtension.Test/DataStoreTests/DataManagerTests.cs
+++ b/GitHubExtension.Test/DataStoreTests/DataManagerTests.cs
@@ -5,7 +5,7 @@
 using GitHubExtension.Client;
 using GitHubExtension.DataManager.Cache;
 using GitHubExtension.DataManager.Data;
-using GitHubExtension.DeveloperId;
+using GitHubExtension.DeveloperIds;
 using Moq;
 
 namespace GitHubExtension.Test.DataStoreTests;

--- a/GitHubExtension.Test/DataStoreTests/OctokitIngestionTests.cs
+++ b/GitHubExtension.Test/DataStoreTests/OctokitIngestionTests.cs
@@ -6,7 +6,7 @@ using Dapper.Contrib.Extensions;
 using GitHubExtension.Client;
 using GitHubExtension.DataModel;
 using GitHubExtension.DataModel.DataObjects;
-using GitHubExtension.DeveloperId;
+using GitHubExtension.DeveloperIds;
 using GitHubExtension.Test.Helpers;
 using Moq;
 using Octokit;

--- a/GitHubExtension.Test/DeveloperIdTests/OAuthRequestTest.cs
+++ b/GitHubExtension.Test/DeveloperIdTests/OAuthRequestTest.cs
@@ -2,7 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using GitHubExtension.DeveloperId;
+using GitHubExtension.DeveloperIds;
 using Moq;
 using Octokit;
 

--- a/GitHubExtension.Test/GitHubExtension.Test.csproj
+++ b/GitHubExtension.Test/GitHubExtension.Test.csproj
@@ -32,4 +32,10 @@
   <ItemGroup>
     <ProjectReference Include="..\GitHubExtension\GitHubExtension.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Assets\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/GitHubExtension.Test/GitHubExtension.Test.csproj
+++ b/GitHubExtension.Test/GitHubExtension.Test.csproj
@@ -33,9 +33,30 @@
     <ProjectReference Include="..\GitHubExtension\GitHubExtension.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Include="Assets\*">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+    <ItemGroup>
+        <Content Include="..\GitHubExtension\Assets\**\*">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="Assets\" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Content Update="..\GitHubExtension\Assets\gh_logo.png" Link="Assets\gh_logo.png" />
+      <Content Update="..\GitHubExtension\Assets\github.dark.svg" Link="Assets\github.dark.svg" />
+      <Content Update="..\GitHubExtension\Assets\github.light.svg" Link="Assets\github.light.svg" />
+      <Content Update="..\GitHubExtension\Assets\issues.svg" Link="Assets\issues.svg" />
+      <Content Update="..\GitHubExtension\Assets\LockScreenLogo.scale-200.png" Link="Assets\LockScreenLogo.scale-200.png" />
+      <Content Update="..\GitHubExtension\Assets\pulls.svg" Link="Assets\pulls.svg" />
+      <Content Update="..\GitHubExtension\Assets\releases.svg" Link="Assets\releases.svg" />
+      <Content Update="..\GitHubExtension\Assets\screenshot.png" Link="Assets\screenshot.png" />
+      <Content Update="..\GitHubExtension\Assets\SplashScreen.scale-200.png" Link="Assets\SplashScreen.scale-200.png" />
+      <Content Update="..\GitHubExtension\Assets\Square150x150Logo.scale-200.png" Link="Assets\Square150x150Logo.scale-200.png" />
+      <Content Update="..\GitHubExtension\Assets\Square44x44Logo.scale-200.png" Link="Assets\Square44x44Logo.scale-200.png" />
+      <Content Update="..\GitHubExtension\Assets\Square44x44Logo.targetsize-24_altform-unplated.png" Link="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
+      <Content Update="..\GitHubExtension\Assets\StoreLogo.png" Link="Assets\StoreLogo.png" />
+      <Content Update="..\GitHubExtension\Assets\Wide310x150Logo.scale-200.png" Link="Assets\Wide310x150Logo.scale-200.png" />
+    </ItemGroup>
 </Project>

--- a/GitHubExtension/Client/GithubClientProvider.cs
+++ b/GitHubExtension/Client/GithubClientProvider.cs
@@ -2,7 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using GitHubExtension.DeveloperId;
+using GitHubExtension.DeveloperIds;
 using Octokit;
 using Serilog;
 

--- a/GitHubExtension/Controls/Commands/SignInCommand.cs
+++ b/GitHubExtension/Controls/Commands/SignInCommand.cs
@@ -2,7 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using GitHubExtension.DeveloperId;
+using GitHubExtension.DeveloperIds;
 using GitHubExtension.Helpers;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;

--- a/GitHubExtension/Controls/Commands/SignOutCommand.cs
+++ b/GitHubExtension/Controls/Commands/SignOutCommand.cs
@@ -2,7 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using GitHubExtension.DeveloperId;
+using GitHubExtension.DeveloperIds;
 using GitHubExtension.Helpers;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;

--- a/GitHubExtension/Controls/Forms/SignInForm.cs
+++ b/GitHubExtension/Controls/Forms/SignInForm.cs
@@ -4,7 +4,7 @@
 
 using System.Globalization;
 using GitHubExtension.Controls.Commands;
-using GitHubExtension.DeveloperId;
+using GitHubExtension.DeveloperIds;
 using GitHubExtension.Helpers;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;

--- a/GitHubExtension/Controls/Forms/SignOutForm.cs
+++ b/GitHubExtension/Controls/Forms/SignOutForm.cs
@@ -4,7 +4,7 @@
 
 using System.Globalization;
 using GitHubExtension.Controls.Commands;
-using GitHubExtension.DeveloperId;
+using GitHubExtension.DeveloperIds;
 using GitHubExtension.Helpers;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;

--- a/GitHubExtension/Controls/Forms/SignOutForm.cs
+++ b/GitHubExtension/Controls/Forms/SignOutForm.cs
@@ -4,6 +4,7 @@
 
 using System.Globalization;
 using GitHubExtension.Controls.Commands;
+using GitHubExtension.DeveloperId;
 using GitHubExtension.Helpers;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
@@ -15,16 +16,18 @@ public partial class SignOutForm : FormContent
     private readonly IResources _resources;
     private readonly SignOutCommand _signOutCommand;
     private readonly AuthenticationMediator _authenticationMediator;
+    private readonly IDeveloperIdProvider _developerIdProvider;
     private bool _isButtonEnabled = true;
 
     private string IsButtonEnabled =>
     _isButtonEnabled.ToString(CultureInfo.InvariantCulture).ToLower(CultureInfo.InvariantCulture);
 
-    public SignOutForm(IResources resources, AuthenticationMediator authenticationMediator, SignOutCommand signOutCommand)
+    public SignOutForm(IResources resources, AuthenticationMediator authenticationMediator, SignOutCommand signOutCommand, IDeveloperIdProvider developerIdProvider)
     {
         _resources = resources;
         _signOutCommand = signOutCommand;
         _authenticationMediator = authenticationMediator;
+        _developerIdProvider = developerIdProvider;
         _authenticationMediator.LoadingStateChanged += OnLoadingStateChanged;
         _authenticationMediator.SignInAction += ResetButton;
         _authenticationMediator.SignOutAction += ResetButton;
@@ -53,7 +56,7 @@ public partial class SignOutForm : FormContent
     public Dictionary<string, string> TemplateSubstitutions => new()
     {
         { "{{AuthTitle}}", _resources.GetResource("Forms_Sign_Out_Title") },
-        { "{{AuthButtonTitle}}", _resources.GetResource("Forms_Sign_Out_Button_Title") },
+        { "{{AuthButtonTitle}}", $"{_resources.GetResource("Forms_Sign_Out_Button_Title")} {_developerIdProvider.GetLoggedInDeveloperId()?.LoginId ?? string.Empty}" },
         { "{{AuthIcon}}", $"data:image/png;base64,{GitHubIcon.GetBase64Icon(GitHubIcon.LogoWithBackplatePath)}" },
         { "{{AuthButtonTooltip}}", _resources.GetResource("Forms_Sign_Out_Tooltip") },
         { "{{ButtonIsEnabled}}", IsButtonEnabled },

--- a/GitHubExtension/DataManager/Data/DataStoreOperationParameters.cs
+++ b/GitHubExtension/DataManager/Data/DataStoreOperationParameters.cs
@@ -4,7 +4,7 @@
 
 using GitHubExtension.DataManager.Enums;
 using GitHubExtension.DataModel.Enums;
-using GitHubExtension.DeveloperId;
+using GitHubExtension.DeveloperIds;
 
 namespace GitHubExtension.DataManager.Data;
 

--- a/GitHubExtension/DataModel/DataObjects/User.cs
+++ b/GitHubExtension/DataModel/DataObjects/User.cs
@@ -4,7 +4,7 @@
 
 using Dapper;
 using Dapper.Contrib.Extensions;
-using GitHubExtension.DeveloperId;
+using GitHubExtension.DeveloperIds;
 using GitHubExtension.Helpers;
 using Serilog;
 

--- a/GitHubExtension/DeveloperId/CredentialManager.cs
+++ b/GitHubExtension/DeveloperId/CredentialManager.cs
@@ -4,7 +4,7 @@
 
 using System.Runtime.InteropServices;
 
-namespace GitHubExtension.DeveloperId;
+namespace GitHubExtension.DeveloperIds;
 
 public static class CredentialManager
 {

--- a/GitHubExtension/DeveloperId/CredentialVault.cs
+++ b/GitHubExtension/DeveloperId/CredentialVault.cs
@@ -7,9 +7,9 @@ using System.Runtime.InteropServices;
 using System.Security;
 using Serilog;
 using Windows.Security.Credentials;
-using static GitHubExtension.DeveloperId.CredentialManager;
+using static GitHubExtension.DeveloperIds.CredentialManager;
 
-namespace GitHubExtension.DeveloperId;
+namespace GitHubExtension.DeveloperIds;
 
 public class CredentialVault(string applicationName = "") : ICredentialVault
 {

--- a/GitHubExtension/DeveloperId/DeveloperId.cs
+++ b/GitHubExtension/DeveloperId/DeveloperId.cs
@@ -4,7 +4,7 @@
 
 using Octokit;
 
-namespace GitHubExtension.DeveloperId;
+namespace GitHubExtension.DeveloperIds;
 
 public class DeveloperId : IDeveloperId
 {

--- a/GitHubExtension/DeveloperId/DeveloperIdProvider.cs
+++ b/GitHubExtension/DeveloperId/DeveloperIdProvider.cs
@@ -205,6 +205,14 @@ public class DeveloperIdProvider : IDeveloperIdProvider
         return iDeveloperIds;
     }
 
+    public IDeveloperId? GetLoggedInDeveloperId()
+    {
+        lock (_developerIdsLock)
+        {
+            return DeveloperIds?.FirstOrDefault();
+        }
+    }
+
     // Convert devID to internal devID.
     public IDeveloperId GetDeveloperIdInternal(IDeveloperId devId)
     {

--- a/GitHubExtension/DeveloperId/DeveloperIdProvider.cs
+++ b/GitHubExtension/DeveloperId/DeveloperIdProvider.cs
@@ -8,7 +8,7 @@ using Octokit;
 using Serilog;
 using Windows.Foundation;
 
-namespace GitHubExtension.DeveloperId;
+namespace GitHubExtension.DeveloperIds;
 
 public class DeveloperIdProvider : IDeveloperIdProvider
 {

--- a/GitHubExtension/DeveloperId/ICredentialVault.cs
+++ b/GitHubExtension/DeveloperId/ICredentialVault.cs
@@ -5,7 +5,7 @@
 using System.Security;
 using Windows.Security.Credentials;
 
-namespace GitHubExtension.DeveloperId;
+namespace GitHubExtension.DeveloperIds;
 
 public interface ICredentialVault
 {

--- a/GitHubExtension/DeveloperId/IDeveloperId.cs
+++ b/GitHubExtension/DeveloperId/IDeveloperId.cs
@@ -2,7 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace GitHubExtension.DeveloperId;
+namespace GitHubExtension.DeveloperIds;
 
 public interface IDeveloperId
 {

--- a/GitHubExtension/DeveloperId/IDeveloperIdProvider.cs
+++ b/GitHubExtension/DeveloperId/IDeveloperIdProvider.cs
@@ -4,7 +4,7 @@
 
 using Windows.Foundation;
 
-namespace GitHubExtension.DeveloperId;
+namespace GitHubExtension.DeveloperIds;
 
 public interface IDeveloperIdProvider
 {

--- a/GitHubExtension/DeveloperId/IDeveloperIdProvider.cs
+++ b/GitHubExtension/DeveloperId/IDeveloperIdProvider.cs
@@ -10,6 +10,8 @@ public interface IDeveloperIdProvider
 {
     IEnumerable<IDeveloperId> GetLoggedInDeveloperIdsInternal();
 
+    IDeveloperId? GetLoggedInDeveloperId();
+
     IDeveloperId GetDeveloperIdInternal(IDeveloperId devId);
 
     IAsyncOperation<IDeveloperId> LoginNewDeveloperIdAsync();
@@ -20,5 +22,5 @@ public interface IDeveloperIdProvider
 
     bool IsSignedIn();
 
-    public event EventHandler<Exception?>? OAuthRedirected;
+    event EventHandler<Exception?>? OAuthRedirected;
 }

--- a/GitHubExtension/DeveloperId/OAuthRequest.cs
+++ b/GitHubExtension/DeveloperId/OAuthRequest.cs
@@ -13,7 +13,7 @@ using Serilog;
 
 [assembly: InternalsVisibleTo("GitHubExtension.Test")]
 
-namespace GitHubExtension.DeveloperId;
+namespace GitHubExtension.DeveloperIds;
 
 internal sealed class OAuthRequest : IDisposable
 {

--- a/GitHubExtension/GitHubExtensionCommandsProvider.cs
+++ b/GitHubExtension/GitHubExtensionCommandsProvider.cs
@@ -5,7 +5,7 @@
 using System.Diagnostics;
 using GitHubExtension.Controls;
 using GitHubExtension.Controls.Pages;
-using GitHubExtension.DeveloperId;
+using GitHubExtension.DeveloperIds;
 using GitHubExtension.Helpers;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;

--- a/GitHubExtension/Program.cs
+++ b/GitHubExtension/Program.cs
@@ -11,7 +11,7 @@ using GitHubExtension.Controls.Pages;
 using GitHubExtension.DataManager;
 using GitHubExtension.DataManager.Cache;
 using GitHubExtension.DataManager.Data;
-using GitHubExtension.DeveloperId;
+using GitHubExtension.DeveloperIds;
 using GitHubExtension.Helpers;
 using GitHubExtension.PersistentData;
 using Microsoft.CommandPalette.Extensions;

--- a/GitHubExtension/Program.cs
+++ b/GitHubExtension/Program.cs
@@ -142,7 +142,7 @@ public class Program
         var savedSearchesPage = new SavedSearchesPage(searchPageFactory, searchRepository, resources, addSearchListItem, savedSearchesMediator);
 
         var signOutCommand = new SignOutCommand(resources, developerIdProvider, authenticationMediator);
-        var signOutForm = new SignOutForm(resources, authenticationMediator, signOutCommand);
+        var signOutForm = new SignOutForm(resources, authenticationMediator, signOutCommand, developerIdProvider);
         var signOutPage = new SignOutPage(resources, signOutForm, signOutCommand, authenticationMediator);
         var signInCommand = new SignInCommand(resources, developerIdProvider, authenticationMediator);
         var signInForm = new SignInForm(authenticationMediator, resources, developerIdProvider, signInCommand);


### PR DESCRIPTION
Before:
- Sign out button said "Sign out"

After
- Sign out button said "Sign out {login}"
- There was a massive rename of `GitHubExtension.DeveloperId` --> `GitHubExtension.DeveloperIds` because using the DeveloperId class in the tests didn't work with the `GitHubExtension.DeveloperId` namespace ('DeveloperId' is a namespace but is used like a type)