### PR TITLE
Allow double quotes in search names and titles

### DIFF
--- a/GitHubExtension.Test/Controls/GitHubQueryValidationTests.cs
+++ b/GitHubExtension.Test/Controls/GitHubQueryValidationTests.cs
@@ -195,7 +195,10 @@ public class GitHubQueryValidationTests
         var saveSearchForm = new SaveSearchForm(persistentDataManager, mockResources, savedSearchesMediator);
 
         // Create search string and payload
-        var testSearchString = "is:open is:issue label:\\\"Product-Command Palette\\\"";
+        // var testSearchString = "is:open is:issue label:\\\"Product-Command Palette\\\""; // parses, but doesn't match original
+        var testSearchString = "is:open is:issue label:\"Product-Command Palette\""; // Use escaped quotes for label
+
+        // {"EnteredSearch":"is:issue state:open label:\"Product-Command Palette\" ","IsTopLevel":"false","Name":"Test"} // actual input
         var payload = CreatePayload(testSearchString, "Test Search");
         saveSearchForm.SubmitForm(payload, string.Empty);
 

--- a/GitHubExtension.Test/Controls/GitHubQueryValidationTests.cs
+++ b/GitHubExtension.Test/Controls/GitHubQueryValidationTests.cs
@@ -195,7 +195,7 @@ public class GitHubQueryValidationTests
         var saveSearchForm = new SaveSearchForm(persistentDataManager, mockResources, savedSearchesMediator);
 
         // Create search string and payload
-        var testSearchString = "is:open label:\"Product-Command Palette\"";
+        var testSearchString = "is:open is:issue label:\\\"Product-Command Palette\\\"";
         var payload = CreatePayload(testSearchString, "Test Search");
         saveSearchForm.SubmitForm(payload, string.Empty);
 

--- a/GitHubExtension.Test/Controls/GitHubQueryValidationTests.cs
+++ b/GitHubExtension.Test/Controls/GitHubQueryValidationTests.cs
@@ -195,7 +195,7 @@ public class GitHubQueryValidationTests
         var saveSearchForm = new SaveSearchForm(persistentDataManager, mockResources, savedSearchesMediator);
 
         // Create search string and payload
-        var testSearchString = "state:open label:bug";
+        var testSearchString = "is:open label:\"Product-Command Palette\"";
         var payload = CreatePayload(testSearchString, "Test Search");
         saveSearchForm.SubmitForm(payload, string.Empty);
 

--- a/GitHubExtension.Test/Controls/GitHubQueryValidationTests.cs
+++ b/GitHubExtension.Test/Controls/GitHubQueryValidationTests.cs
@@ -195,14 +195,11 @@ public class GitHubQueryValidationTests
         var saveSearchForm = new SaveSearchForm(persistentDataManager, mockResources, savedSearchesMediator);
 
         // Create search string and payload
-        // var testSearchString = "is:open is:issue label:\\\"Product-Command Palette\\\""; // parses, but doesn't match original
-        var testSearchString = "is:open is:issue label:\"Product-Command Palette\""; // Use escaped quotes for label
-
-        // {"EnteredSearch":"is:issue state:open label:\"Product-Command Palette\" ","IsTopLevel":"false","Name":"Test"} // actual input
-        var payload = CreatePayload(testSearchString, "Test Search");
+        var testSearchString = "is:issue state:open label:\"Product-Command Palette\"";
+        var payload = "{\"EnteredSearch\":\"is:issue state:open label:\\\"Product-Command Palette\\\"\",\"IsTopLevel\":\"false\",\"Name\":\"test\"}";
         saveSearchForm.SubmitForm(payload, string.Empty);
 
-        await Task.Delay(5000); // Simulate async operation
+        await Task.Delay(1000); // Simulate async operation
 
         // Validate the search
         var searches = await persistentDataManager.GetSavedSearches();

--- a/GitHubExtension/Controls/Forms/SaveSearchForm.cs
+++ b/GitHubExtension/Controls/Forms/SaveSearchForm.cs
@@ -31,8 +31,8 @@ public sealed partial class SaveSearchForm : FormContent, IGitHubForm
     public Dictionary<string, string> TemplateSubstitutions => new()
     {
         { "{{SaveSearchFormTitle}}", _resources.GetResource(string.IsNullOrWhiteSpace(_savedSearch.Name) ? "Forms_Save_Search" : "Forms_Edit_Search") },
-        { "{{SavedSearchString}}", _savedSearch.SearchString },
-        { "{{SavedSearchName}}", _savedSearch.Name },
+        { "{{SavedSearchString}}", TemplateHelper.EscapeStringLiteralForJson(_savedSearch.SearchString) },
+        { "{{SavedSearchName}}", TemplateHelper.EscapeStringLiteralForJson(_savedSearch.Name) },
         { "{{IsTopLevel}}", IsTopLevelChecked },
         { "{{EnteredSearchErrorMessage}}", _resources.GetResource("Forms_SaveSearchTemplateEnteredSearchError") },
         { "{{EnteredSearchLabel}}", _resources.GetResource("Forms_SaveSearchTemplateEnteredSearchLabel") },

--- a/GitHubExtension/Controls/Forms/SaveSearchForm.cs
+++ b/GitHubExtension/Controls/Forms/SaveSearchForm.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using GitHubExtension.Client;
 using GitHubExtension.Helpers;
@@ -31,8 +32,8 @@ public sealed partial class SaveSearchForm : FormContent, IGitHubForm
     public Dictionary<string, string> TemplateSubstitutions => new()
     {
         { "{{SaveSearchFormTitle}}", _resources.GetResource(string.IsNullOrWhiteSpace(_savedSearch.Name) ? "Forms_Save_Search" : "Forms_Edit_Search") },
-        { "{{SavedSearchString}}", TemplateHelper.EscapeStringLiteralForJson(_savedSearch.SearchString) },
-        { "{{SavedSearchName}}", TemplateHelper.EscapeStringLiteralForJson(_savedSearch.Name) },
+        { "{{SavedSearchString}}", JsonSerializer.Serialize(_savedSearch.SearchString) },
+        { "{{SavedSearchName}}", JsonSerializer.Serialize(_savedSearch.Name) },
         { "{{IsTopLevel}}", IsTopLevelChecked },
         { "{{EnteredSearchErrorMessage}}", _resources.GetResource("Forms_SaveSearchTemplateEnteredSearchError") },
         { "{{EnteredSearchLabel}}", _resources.GetResource("Forms_SaveSearchTemplateEnteredSearchLabel") },

--- a/GitHubExtension/Controls/Forms/SaveSearchForm.cs
+++ b/GitHubExtension/Controls/Forms/SaveSearchForm.cs
@@ -119,6 +119,7 @@ public sealed partial class SaveSearchForm : FormContent, IGitHubForm
     public static SearchCandidate CreateSearchFromJson(JsonNode? jsonNode)
     {
         var enteredSearch = jsonNode?["EnteredSearch"]?.ToString() ?? string.Empty;
+
         var name = jsonNode?["Name"]?.ToString() ?? string.Empty;
         var isTopLevel = jsonNode?["IsTopLevel"]?.ToString() == "true";
 

--- a/GitHubExtension/Helpers/TemplateHelper.cs
+++ b/GitHubExtension/Helpers/TemplateHelper.cs
@@ -40,14 +40,4 @@ public static class TemplateHelper
 
         return jsonTemplate;
     }
-
-    public static string EscapeStringLiteralForJson(string input)
-    {
-        if (string.IsNullOrEmpty(input))
-        {
-            return input ?? string.Empty;
-        }
-
-        return input.Replace("\"", "\\\"");
-    }
 }

--- a/GitHubExtension/Helpers/TemplateHelper.cs
+++ b/GitHubExtension/Helpers/TemplateHelper.cs
@@ -40,4 +40,14 @@ public static class TemplateHelper
 
         return jsonTemplate;
     }
+
+    public static string EscapeStringLiteralForJson(string input)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            return input ?? string.Empty;
+        }
+
+        return input.Replace("\"", "\\\"");
+    }
 }


### PR DESCRIPTION
Resolves: #231

Before:
- If double quotes were used, the search would not be reloaded in the template correctly. For example, a query string with "a tag" label would lose the label if the edit query page was opened.

The problem: JSON uses escaped strings as part of its schema. Double quotes within a value in a JSON dictionary have three backslashes instead of one. The forms were correctly parsing this notation into a single backlash escaped quotation mark, but when the query was redisplayed in the form, the escaped quotation mark wasn't converted back to a JSON friendly format, which caused double quoted substrings to be dropped.

After:
- Serialize the name and search strings before rendering the form