### PR TITLE
Fix form parsing

### DIFF
--- a/GitHubExtension.Test/Controls/SignOutFormTests.cs
+++ b/GitHubExtension.Test/Controls/SignOutFormTests.cs
@@ -91,7 +91,6 @@ public class SignOutFormTests
         Assert.IsTrue(JsonSerializer.Deserialize<string>(dict["{{AuthIcon}}"])?.StartsWith("data:image/png;base64,", StringComparison.Ordinal));
         Assert.AreEqual(expectedTooltip, JsonSerializer.Deserialize<string>(dict["{{AuthButtonTooltip}}"]));
 
-        // Deserialize as bool for ButtonIsEnabled
         Assert.AreEqual(expectedButtonEnabled, JsonSerializer.Deserialize<bool>(dict["{{ButtonIsEnabled}}"]));
     }
 
@@ -126,7 +125,7 @@ public class SignOutFormTests
         method!.Invoke(ctx.Form, new object[] { isEnabled });
 
         var dict = ctx.Form.TemplateSubstitutions;
-        Assert.AreEqual(expected.ToString().ToLowerInvariant(), JsonSerializer.Deserialize<string>(dict["{{ButtonIsEnabled}}"]));
+        Assert.AreEqual(expected, JsonSerializer.Deserialize<bool>(dict["{{ButtonIsEnabled}}"]));
     }
 
     [TestMethod]
@@ -138,7 +137,7 @@ public class SignOutFormTests
         method!.Invoke(ctx.Form, new object?[] { null, args });
 
         var dict = ctx.Form.TemplateSubstitutions;
-        Assert.AreEqual("false", JsonSerializer.Deserialize<string>(dict["{{ButtonIsEnabled}}"]));
+        Assert.AreEqual(false, JsonSerializer.Deserialize<bool>(dict["{{ButtonIsEnabled}}"]));
     }
 
     [TestMethod]
@@ -149,7 +148,7 @@ public class SignOutFormTests
         method!.Invoke(ctx.Form, new object[] { new(), true });
 
         var dict = ctx.Form.TemplateSubstitutions;
-        Assert.AreEqual("false", JsonSerializer.Deserialize<string>(dict["{{ButtonIsEnabled}}"]));
+        Assert.AreEqual(false, JsonSerializer.Deserialize<bool>(dict["{{ButtonIsEnabled}}"]));
     }
 
     [TestMethod]

--- a/GitHubExtension.Test/Controls/SignOutFormTests.cs
+++ b/GitHubExtension.Test/Controls/SignOutFormTests.cs
@@ -137,7 +137,7 @@ public class SignOutFormTests
         method!.Invoke(ctx.Form, new object?[] { null, args });
 
         var dict = ctx.Form.TemplateSubstitutions;
-        Assert.AreEqual(false, JsonSerializer.Deserialize<bool>(dict["{{ButtonIsEnabled}}"]));
+        Assert.IsFalse(JsonSerializer.Deserialize<bool>(dict["{{ButtonIsEnabled}}"]));
     }
 
     [TestMethod]
@@ -148,7 +148,7 @@ public class SignOutFormTests
         method!.Invoke(ctx.Form, new object[] { new(), true });
 
         var dict = ctx.Form.TemplateSubstitutions;
-        Assert.AreEqual(false, JsonSerializer.Deserialize<bool>(dict["{{ButtonIsEnabled}}"]));
+        Assert.IsFalse(JsonSerializer.Deserialize<bool>(dict["{{ButtonIsEnabled}}"]));
     }
 
     [TestMethod]

--- a/GitHubExtension.Test/Controls/SignOutFormTests.cs
+++ b/GitHubExtension.Test/Controls/SignOutFormTests.cs
@@ -90,7 +90,9 @@ public class SignOutFormTests
 
         Assert.IsTrue(JsonSerializer.Deserialize<string>(dict["{{AuthIcon}}"])?.StartsWith("data:image/png;base64,", StringComparison.Ordinal));
         Assert.AreEqual(expectedTooltip, JsonSerializer.Deserialize<string>(dict["{{AuthButtonTooltip}}"]));
-        Assert.AreEqual(expectedButtonEnabled.ToString().ToLowerInvariant(), JsonSerializer.Deserialize<string>(dict["{{ButtonIsEnabled}}"]));
+
+        // Deserialize as bool for ButtonIsEnabled
+        Assert.AreEqual(expectedButtonEnabled, JsonSerializer.Deserialize<bool>(dict["{{ButtonIsEnabled}}"]));
     }
 
     [TestMethod]

--- a/GitHubExtension.Test/Controls/SignOutFormTests.cs
+++ b/GitHubExtension.Test/Controls/SignOutFormTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
+using System.Text.Json;
 using GitHubExtension.Controls;
 using GitHubExtension.Controls.Commands;
 using GitHubExtension.Controls.Forms;
@@ -67,28 +68,29 @@ public class SignOutFormTests
     [TestMethod]
     public void Constructor_RegistersEventHandlers()
     {
-        // Just verify events exist (event handler registration is not directly testable without raising events)
         Assert.IsNotNull(typeof(AuthenticationMediator).GetEvent("LoadingStateChanged"));
         Assert.IsNotNull(typeof(AuthenticationMediator).GetEvent("SignInAction"));
         Assert.IsNotNull(typeof(AuthenticationMediator).GetEvent("SignOutAction"));
     }
 
-    [DataRow("user1", "res_Forms_Sign_Out_Title", true, "res_Forms_Sign_Out_Tooltip", "true")]
-    [DataRow(null, "res_Forms_Sign_Out_Title", false, "res_Forms_Sign_Out_Tooltip", "true")]
+    [DataRow("user1", "res_Forms_Sign_Out_Title", true, "res_Forms_Sign_Out_Tooltip", true)]
+    [DataRow(null, "res_Forms_Sign_Out_Title", false, "res_Forms_Sign_Out_Tooltip", true)]
     [TestMethod]
-    public void TemplateSubstitutions_ReturnsExpectedValues(string? developerId, string expectedTitle, bool expectUserName, string expectedTooltip, string expectedButtonEnabled)
+    public void TemplateSubstitutions_ReturnsExpectedValues(string? developerId, string expectedTitle, bool expectUserName, string expectedTooltip, bool expectedButtonEnabled)
     {
         var ctx = CreateTestContext(developerId: developerId);
         var dict = ctx.Form.TemplateSubstitutions;
-        Assert.AreEqual(expectedTitle, dict["{{AuthTitle}}"]);
+
+        // All values are now JSON-serialized, so we must deserialize to check the actual value
+        Assert.AreEqual(expectedTitle, JsonSerializer.Deserialize<string>(dict["{{AuthTitle}}"]));
         if (expectUserName)
         {
-            Assert.IsTrue(dict["{{AuthButtonTitle}}"].Contains("user1"));
+            Assert.IsTrue(JsonSerializer.Deserialize<string>(dict["{{AuthButtonTitle}}"])?.Contains("user1"));
         }
 
-        Assert.IsTrue(dict["{{AuthIcon}}"].StartsWith("data:image/png;base64,", StringComparison.Ordinal));
-        Assert.AreEqual(expectedTooltip, dict["{{AuthButtonTooltip}}"]);
-        Assert.AreEqual(expectedButtonEnabled, dict["{{ButtonIsEnabled}}"]);
+        Assert.IsTrue(JsonSerializer.Deserialize<string>(dict["{{AuthIcon}}"])?.StartsWith("data:image/png;base64,", StringComparison.Ordinal));
+        Assert.AreEqual(expectedTooltip, JsonSerializer.Deserialize<string>(dict["{{AuthButtonTooltip}}"]));
+        Assert.AreEqual(expectedButtonEnabled.ToString().ToLowerInvariant(), JsonSerializer.Deserialize<string>(dict["{{ButtonIsEnabled}}"]));
     }
 
     [TestMethod]
@@ -112,17 +114,17 @@ public class SignOutFormTests
         Assert.IsNotNull(result);
     }
 
-    [DataRow(false, "false")]
-    [DataRow(true, "true")]
+    [DataRow(false, false)]
+    [DataRow(true, true)]
     [TestMethod]
-    public void SetButtonEnabled_UpdatesButtonState(bool isEnabled, string expected)
+    public void SetButtonEnabled_UpdatesButtonState(bool isEnabled, bool expected)
     {
         var ctx = CreateTestContext();
         var method = typeof(SignOutForm).GetMethod("SetButtonEnabled", BindingFlags.NonPublic | BindingFlags.Instance);
         method!.Invoke(ctx.Form, new object[] { isEnabled });
 
         var dict = ctx.Form.TemplateSubstitutions;
-        Assert.AreEqual(expected, dict["{{ButtonIsEnabled}}"]);
+        Assert.AreEqual(expected.ToString().ToLowerInvariant(), JsonSerializer.Deserialize<string>(dict["{{ButtonIsEnabled}}"]));
     }
 
     [TestMethod]
@@ -134,7 +136,7 @@ public class SignOutFormTests
         method!.Invoke(ctx.Form, new object?[] { null, args });
 
         var dict = ctx.Form.TemplateSubstitutions;
-        Assert.AreEqual("false", dict["{{ButtonIsEnabled}}"]);
+        Assert.AreEqual("false", JsonSerializer.Deserialize<string>(dict["{{ButtonIsEnabled}}"]));
     }
 
     [TestMethod]
@@ -145,7 +147,7 @@ public class SignOutFormTests
         method!.Invoke(ctx.Form, new object[] { new(), true });
 
         var dict = ctx.Form.TemplateSubstitutions;
-        Assert.AreEqual("false", dict["{{ButtonIsEnabled}}"]);
+        Assert.AreEqual("false", JsonSerializer.Deserialize<string>(dict["{{ButtonIsEnabled}}"]));
     }
 
     [TestMethod]
@@ -153,8 +155,8 @@ public class SignOutFormTests
     {
         var ctx = CreateTestContext(resourceFunc: _ => null);
         var dict = ctx.Form.TemplateSubstitutions;
-        Assert.AreEqual(dict["{{AuthTitle}}"], "Forms_Sign_Out_Title");
-        Assert.AreEqual(dict["{{AuthButtonTooltip}}"], "Forms_Sign_Out_Tooltip");
+        Assert.AreEqual("Forms_Sign_Out_Title", JsonSerializer.Deserialize<string>(dict["{{AuthTitle}}"]));
+        Assert.AreEqual("Forms_Sign_Out_Tooltip", JsonSerializer.Deserialize<string>(dict["{{AuthButtonTooltip}}"]));
     }
 
     [TestMethod]

--- a/GitHubExtension/Controls/Forms/SaveSearchForm.cs
+++ b/GitHubExtension/Controls/Forms/SaveSearchForm.cs
@@ -31,16 +31,16 @@ public sealed partial class SaveSearchForm : FormContent, IGitHubForm
 
     public Dictionary<string, string> TemplateSubstitutions => new()
     {
-        { "{{SaveSearchFormTitle}}", _resources.GetResource(string.IsNullOrWhiteSpace(_savedSearch.Name) ? "Forms_Save_Search" : "Forms_Edit_Search") },
+        { "{{SaveSearchFormTitle}}", JsonSerializer.Serialize(_resources.GetResource(string.IsNullOrWhiteSpace(_savedSearch.Name) ? "Forms_Save_Search" : "Forms_Edit_Search")) },
         { "{{SavedSearchString}}", JsonSerializer.Serialize(_savedSearch.SearchString) },
         { "{{SavedSearchName}}", JsonSerializer.Serialize(_savedSearch.Name) },
-        { "{{IsTopLevel}}", IsTopLevelChecked },
-        { "{{EnteredSearchErrorMessage}}", _resources.GetResource("Forms_SaveSearchTemplateEnteredSearchError") },
-        { "{{EnteredSearchLabel}}", _resources.GetResource("Forms_SaveSearchTemplateEnteredSearchLabel") },
-        { "{{NameLabel}}", _resources.GetResource("Forms_SaveSearchTemplateNameLabel") },
-        { "{{NameErrorMessage}}", _resources.GetResource("Forms_SaveSearchTemplateNameError") },
-        { "{{IsTopLevelTitle}}", _resources.GetResource("Forms_SaveSearchTemplateIsTopLevelTitle") },
-        { "{{SaveSearchActionTitle}}", _resources.GetResource(string.IsNullOrWhiteSpace(_savedSearch.Name) ? "Forms_SaveSearchTemplateSaveSearchActionTitle" : "Forms_SaveSearchTemplateEditSearchActionTitle") },
+        { "{{IsTopLevel}}", JsonSerializer.Serialize(IsTopLevelChecked) },
+        { "{{EnteredSearchErrorMessage}}", JsonSerializer.Serialize(_resources.GetResource("Forms_SaveSearchTemplateEnteredSearchError")) },
+        { "{{EnteredSearchLabel}}", JsonSerializer.Serialize(_resources.GetResource("Forms_SaveSearchTemplateEnteredSearchLabel")) },
+        { "{{NameLabel}}", JsonSerializer.Serialize(_resources.GetResource("Forms_SaveSearchTemplateNameLabel")) },
+        { "{{NameErrorMessage}}", JsonSerializer.Serialize(_resources.GetResource("Forms_SaveSearchTemplateNameError")) },
+        { "{{IsTopLevelTitle}}", JsonSerializer.Serialize(_resources.GetResource("Forms_SaveSearchTemplateIsTopLevelTitle")) },
+        { "{{SaveSearchActionTitle}}", JsonSerializer.Serialize(_resources.GetResource(string.IsNullOrWhiteSpace(_savedSearch.Name) ? "Forms_SaveSearchTemplateSaveSearchActionTitle" : "Forms_SaveSearchTemplateEditSearchActionTitle")) },
     };
 
     // for saving a new query

--- a/GitHubExtension/Controls/Forms/SignInForm.cs
+++ b/GitHubExtension/Controls/Forms/SignInForm.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
+using System.Text.Json;
 using GitHubExtension.Controls.Commands;
 using GitHubExtension.DeveloperIds;
 using GitHubExtension.Helpers;
@@ -75,11 +76,11 @@ public partial class SignInForm : FormContent, IDisposable
 
     public Dictionary<string, string> TemplateSubstitutions => new()
     {
-        { "{{AuthTitle}}", _resources.GetResource("Forms_Sign_In") },
-        { "{{AuthButtonTitle}}", _resources.GetResource("Forms_Sign_In") },
-        { "{{AuthIcon}}", $"data:image/png;base64,{GitHubIcon.GetBase64Icon(GitHubIcon.LogoWithBackplatePath)}" },
-        { "{{AuthButtonTooltip}}", _resources.GetResource("Forms_Sign_In_Tooltip") },
-        { "{{ButtonIsEnabled}}", IsButtonEnabled },
+        { "{{AuthTitle}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Sign_In")) },
+        { "{{AuthButtonTitle}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Sign_In")) },
+        { "{{AuthIcon}}", JsonSerializer.Serialize($"data:image/png;base64,{GitHubIcon.GetBase64Icon(GitHubIcon.LogoWithBackplatePath)}") },
+        { "{{AuthButtonTooltip}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Sign_In_Tooltip")) },
+        { "{{ButtonIsEnabled}}", JsonSerializer.Serialize(IsButtonEnabled) },
     };
 
     public override string TemplateJson => TemplateHelper.LoadTemplateJsonFromTemplateName("AuthTemplate", TemplateSubstitutions);

--- a/GitHubExtension/Controls/Forms/SignInForm.cs
+++ b/GitHubExtension/Controls/Forms/SignInForm.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Globalization;
 using System.Text.Json;
 using GitHubExtension.Controls.Commands;
 using GitHubExtension.DeveloperIds;
@@ -20,9 +19,6 @@ public partial class SignInForm : FormContent, IDisposable
     private readonly SignInCommand _signInCommand;
 
     private bool _isButtonEnabled = true;
-
-    private string IsButtonEnabled =>
-        _isButtonEnabled.ToString(CultureInfo.InvariantCulture).ToLower(CultureInfo.InvariantCulture);
 
     public SignInForm(AuthenticationMediator authenticationMediator, IResources resources, IDeveloperIdProvider developerIdProvider, SignInCommand signInCommand)
     {
@@ -80,7 +76,7 @@ public partial class SignInForm : FormContent, IDisposable
         { "{{AuthButtonTitle}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Sign_In")) },
         { "{{AuthIcon}}", JsonSerializer.Serialize($"data:image/png;base64,{GitHubIcon.GetBase64Icon(GitHubIcon.LogoWithBackplatePath)}") },
         { "{{AuthButtonTooltip}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Sign_In_Tooltip")) },
-        { "{{ButtonIsEnabled}}", JsonSerializer.Serialize(IsButtonEnabled) },
+        { "{{ButtonIsEnabled}}", JsonSerializer.Serialize(_isButtonEnabled) },
     };
 
     public override string TemplateJson => TemplateHelper.LoadTemplateJsonFromTemplateName("AuthTemplate", TemplateSubstitutions);

--- a/GitHubExtension/Controls/Forms/SignOutForm.cs
+++ b/GitHubExtension/Controls/Forms/SignOutForm.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
+using System.Text.Json;
 using GitHubExtension.Controls.Commands;
 using GitHubExtension.DeveloperIds;
 using GitHubExtension.Helpers;
@@ -55,11 +56,11 @@ public partial class SignOutForm : FormContent, IDisposable
 
     public Dictionary<string, string> TemplateSubstitutions => new()
     {
-        { "{{AuthTitle}}", _resources.GetResource("Forms_Sign_Out_Title") },
-        { "{{AuthButtonTitle}}", $"{_resources.GetResource("Forms_Sign_Out_Button_Title")} {_developerIdProvider.GetLoggedInDeveloperId()?.LoginId ?? string.Empty}" },
-        { "{{AuthIcon}}", $"data:image/png;base64,{GitHubIcon.GetBase64Icon(GitHubIcon.LogoWithBackplatePath)}" },
-        { "{{AuthButtonTooltip}}", _resources.GetResource("Forms_Sign_Out_Tooltip") },
-        { "{{ButtonIsEnabled}}", IsButtonEnabled },
+        { "{{AuthTitle}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Sign_Out_Title")) },
+        { "{{AuthButtonTitle}}", JsonSerializer.Serialize($"{_resources.GetResource("Forms_Sign_Out_Button_Title")} {_developerIdProvider.GetLoggedInDeveloperId()?.LoginId ?? string.Empty}") },
+        { "{{AuthIcon}}", JsonSerializer.Serialize($"data:image/png;base64,{GitHubIcon.GetBase64Icon(GitHubIcon.LogoWithBackplatePath)}") },
+        { "{{AuthButtonTooltip}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Sign_Out_Tooltip")) },
+        { "{{ButtonIsEnabled}}", JsonSerializer.Serialize(IsButtonEnabled) },
     };
 
     public override string TemplateJson => TemplateHelper.LoadTemplateJsonFromTemplateName("AuthTemplate", TemplateSubstitutions);

--- a/GitHubExtension/Controls/Forms/SignOutForm.cs
+++ b/GitHubExtension/Controls/Forms/SignOutForm.cs
@@ -20,9 +20,6 @@ public partial class SignOutForm : FormContent, IDisposable
     private readonly IDeveloperIdProvider _developerIdProvider;
     private bool _isButtonEnabled = true;
 
-    private string IsButtonEnabled =>
-    _isButtonEnabled.ToString(CultureInfo.InvariantCulture).ToLower(CultureInfo.InvariantCulture);
-
     public SignOutForm(IResources resources, AuthenticationMediator authenticationMediator, SignOutCommand signOutCommand, IDeveloperIdProvider developerIdProvider)
     {
         _resources = resources;
@@ -60,7 +57,7 @@ public partial class SignOutForm : FormContent, IDisposable
         { "{{AuthButtonTitle}}", JsonSerializer.Serialize($"{_resources.GetResource("Forms_Sign_Out_Button_Title")} {_developerIdProvider.GetLoggedInDeveloperId()?.LoginId ?? string.Empty}") },
         { "{{AuthIcon}}", JsonSerializer.Serialize($"data:image/png;base64,{GitHubIcon.GetBase64Icon(GitHubIcon.LogoWithBackplatePath)}") },
         { "{{AuthButtonTooltip}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Sign_Out_Tooltip")) },
-        { "{{ButtonIsEnabled}}", JsonSerializer.Serialize(IsButtonEnabled) },
+        { "{{ButtonIsEnabled}}", JsonSerializer.Serialize(_isButtonEnabled) },
     };
 
     public override string TemplateJson => TemplateHelper.LoadTemplateJsonFromTemplateName("AuthTemplate", TemplateSubstitutions);

--- a/GitHubExtension/Controls/Templates/AuthTemplate.json
+++ b/GitHubExtension/Controls/Templates/AuthTemplate.json
@@ -9,7 +9,7 @@
       "items": [
         {
           "type": "TextBlock",
-          "text": "{{AuthTitle}}",
+          "text": {{AuthTitle}},
           "wrap": true,
           "horizontalAlignment": "center",
           "height": "stretch",
@@ -18,7 +18,7 @@
         },
         {
           "type": "Image",
-          "url": "{{AuthIcon}}",
+          "url": {{AuthIcon}},
           "horizontalAlignment": "center",
           "size": "large"
         },
@@ -37,8 +37,8 @@
                   "type": "ActionSet",
                   "actions": [
                     {
-                      "title": "{{AuthButtonTitle}}",
-                      "tooltip": "{{AuthButtonTooltip}}",
+                      "title": {{AuthButtonTitle}},
+                      "tooltip": {{AuthButtonTooltip}},
                       "type": "Action.Submit",
                       "isEnabled": {{ButtonIsEnabled}}
                     }

--- a/GitHubExtension/Controls/Templates/SaveSearchTemplate.json
+++ b/GitHubExtension/Controls/Templates/SaveSearchTemplate.json
@@ -7,7 +7,7 @@
       "type": "TextBlock",
       "size": "Medium",
       "weight": "Bolder",
-      "text": "{{SaveSearchFormTitle}}",
+      "text": {{SaveSearchFormTitle}},
       "horizontalAlignment": "Center",
       "wrap": true,
       "style": "heading"
@@ -15,18 +15,18 @@
     {
       "type": "Input.Text",
       "id": "Name",
-      "label": "{{NameLabel}}",
+      "label": {{NameLabel}},
       "isRequired": true,
-      "errorMessage": "{{NameErrorMessage}}",
-      "value": "{{SavedSearchName}}"
+      "errorMessage": {{NameErrorMessage}},
+      "value": {{SavedSearchName}}
     },
     {
       "type": "Input.Text",
       "id": "EnteredSearch",
-      "label": "{{EnteredSearchLabel}}",
+      "label": {{EnteredSearchLabel}},
       "isRequired": true,
-      "errorMessage": "{{EnteredSearchErrorMessage}}",
-      "value": "{{SavedSearchString}}"
+      "errorMessage": {{EnteredSearchErrorMessage}},
+      "value": {{SavedSearchString}}
     },
     {
       "type": "ColumnSet",
@@ -39,10 +39,10 @@
             {
               "type": "Input.Toggle",
               "id": "IsTopLevel",
-              "title": "{{IsTopLevelTitle}}",
+              "title": {{IsTopLevelTitle}},
               "valueOn": "true",
               "valueOff": "false",
-              "value": "{{IsTopLevel}}"
+              "value": {{IsTopLevel}}
             }
           ]
         }
@@ -52,7 +52,7 @@
   "actions": [
     {
       "type": "Action.Submit",
-      "title": "{{SaveSearchActionTitle}}",
+      "title": {{SaveSearchActionTitle}},
       "data": {
         "id": "SaveSearchAction"
       }


### PR DESCRIPTION
Before:
- After some recent prs merged in, queries would no longer appear in the edit query form

After:
- All strings are serialized by the JSON Serializer before being inserted into templates (and the templates and tests have been updated accordingly)