### PR TITLE
Update and properly use RemoveSavedSearchEventArgs

### DIFF
--- a/GitHubExtension/Controls/Pages/SavedSearchesPage.cs
+++ b/GitHubExtension/Controls/Pages/SavedSearchesPage.cs
@@ -56,12 +56,12 @@ public partial class SavedSearchesPage : ListPage, IDisposable
 
             toast.Show();
         }
-        else if (args.Status && args.Search != null)
+        else if (args.RemoveSucceeded && args.Search != null)
         {
             RaiseItemsChanged(0);
             ToastHelper.ShowToast($"{_resources.GetResource("Pages_Saved_Searches_RemovedSavedSearchSuccess")} {args.Search?.Name}", MessageState.Success);
         }
-        else if (!args.Status)
+        else if (!args.RemoveSucceeded)
         {
             var toast = new ToastStatusMessage(new StatusMessage()
             {

--- a/GitHubExtension/GitHubExtensionCommandsProvider.cs
+++ b/GitHubExtension/GitHubExtensionCommandsProvider.cs
@@ -57,9 +57,9 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
         _ = UpdateSignInStatus(_developerIdProvider.IsSignedIn());
     }
 
-    private void OnSearchRemoved(object? sender, object? args)
+    private void OnSearchRemoved(object? sender, SavedSearchRemovedEventArgs args)
     {
-        if (args is bool isRemoved && isRemoved)
+        if (args.RemoveSucceeded)
         {
             RaiseItemsChanged(0);
         }

--- a/GitHubExtension/Helpers/SavedSearchRemovedEventArgs.cs
+++ b/GitHubExtension/Helpers/SavedSearchRemovedEventArgs.cs
@@ -8,7 +8,7 @@ namespace GitHubExtension.Helpers;
 
 public class SavedSearchRemovedEventArgs : EventArgs
 {
-    public bool Status { get; }
+    public bool RemoveSucceeded { get; }
 
     public Exception? Exception { get; }
 
@@ -16,7 +16,7 @@ public class SavedSearchRemovedEventArgs : EventArgs
 
     public SavedSearchRemovedEventArgs(bool status, Exception? ex, ISearch search)
     {
-        Status = status;
+        RemoveSucceeded = status;
         Exception = ex;
         Search = search;
     }


### PR DESCRIPTION
This pull request refactors the handling of saved search removal events by renaming a property for better clarity and updating related method signatures and logic to align with this change.

### Refactoring for clarity:

* [`GitHubExtension/Helpers/SavedSearchRemovedEventArgs.cs`](diffhunk://#diff-fa06e47eb8af40b367eb59605f3c900895500b7233cc4d33ec325ed0723d2296L11-R19): Renamed the `Status` property to `RemoveSucceeded` in the `SavedSearchRemovedEventArgs` class to improve readability and better describe its purpose. Updated the constructor to initialize the renamed property.

### Method updates to reflect property rename:

* [`GitHubExtension/Controls/Pages/SavedSearchesPage.cs`](diffhunk://#diff-daeda558e2aae418cdd5a00cb10cb94f2d2aa6aee9a7e0473902fd35abc19f31L59-R64): Updated the `OnSearchRemoved` method to use the renamed `RemoveSucceeded` property instead of `Status` for conditional logic.
* [`GitHubExtension/GitHubExtensionCommandsProvider.cs`](diffhunk://#diff-4cc9299b4a7b0fd718219238a897679ec58d14835f558553a95b02ba0f5ed469L60-R62): Updated the `OnSearchRemoved` method signature to explicitly use `SavedSearchRemovedEventArgs` and replaced the use of `Status` with `RemoveSucceeded` for consistency.