### PR TITLE
Converting from variables to parameters for localization

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -4,6 +4,14 @@ trigger:
 - release
 
 parameters:
+  - name: EnableLocalization
+    displayName: Enable Localization
+    type: boolean
+    default: true
+  - name: UpdateLocalization
+    displayName: Update Localization
+    type: boolean
+    default: true
   - name: Platforms
     type: object
     default:
@@ -57,7 +65,7 @@ extends:
 
                 - task: TouchdownBuildTask@5
                   displayName: Send and Download Localization Files for Artifacts
-                  condition: and(eq(variables['EnableLocalization'], 'true'), eq(variables['UpdateLocalization'], 'true'))
+                  condition: ${{and(eq(parameters.EnableLocalization, 'true'), eq(parameters.UpdateLocalization, 'true'))}}
                   inputs:
                     resourceFilePath: |
                       **\en-US\*.resw
@@ -72,7 +80,7 @@ extends:
 
                 - task: TouchdownBuildTask@5
                   displayName: Download and Use Localization Files
-                  condition: eq(variables['EnableLocalization'], 'true')
+                  condition: ${{eq(parameters.EnableLocalization, 'true')}}
                   inputs:
                     resourceFilePath: |
                       **\en-US\*.resw
@@ -86,7 +94,7 @@ extends:
 
                 - task: PowerShell@2
                   displayName: Move Loc files one level up
-                  condition: eq(variables['EnableLocalization'], 'true')
+                  condition: ${{eq(parameters.EnableLocalization, 'true')}}
                   inputs:
                     targetType: inline
                     script: >-
@@ -101,7 +109,7 @@ extends:
 
                 - task: PowerShell@2
                   displayName: Archive Loc Output for Submission
-                  condition: and(eq(variables['EnableLocalization'], 'true'), eq(variables['UpdateLocalization'], 'true'))
+                  condition: ${{and(eq(parameters.EnableLocalization, 'true'), eq(parameters.UpdateLocalization, 'true'))}}
                   inputs:
                     PathtoPublish: LocOutput.tar.gz
                     ArtifactName: LocOutput
@@ -206,8 +214,8 @@ extends:
                       artifactName: drop_${{ platform }}_${{ configuration }}
                     - output: pipelineArtifact
                       displayName: 'Publish Artifact: LocOutput'
-                      condition: and(eq(variables['EnableLocalization'], 'true'), eq(variables['UpdateLocalization'], 'true'))
+                      condition: ${{and(eq(parameters.EnableLocalization, 'true'), eq(parameters.UpdateLocalization, 'true'))}}
                       artifactName: LocOutput_${{ platform }}_${{ configuration }}
                       targetPath: LocArchive
-                      sbomPackageName: devhomegithubextension.locoutput
+                      sbomPackageName: cmdpalgithubextension.locoutput
                       sbomPackageVersion: $(MSIXVersion)


### PR DESCRIPTION
This pull request updates the Azure Pipelines configuration file to improve parameter handling and streamline localization-related tasks. The changes primarily involve replacing variable-based conditions with parameter-based conditions and adding new pipeline parameters for better configurability.

### Updates to pipeline parameters:
* Added two new parameters, `EnableLocalization` and `UpdateLocalization`, to manage localization tasks more flexibly. Both parameters are of type `boolean` and default to `true`. (`[build/azure-pipelines.ymlR7-R14](diffhunk://#diff-5324d0d190cad8c6fa3025075de2f8f6bb002aca13c2850cb0b36af01af2ff8aR7-R14)`)

### Improvements to task conditions:
* Updated conditions for localization-related tasks to use pipeline parameters (`parameters.EnableLocalization` and `parameters.UpdateLocalization`) instead of variables (`variables['EnableLocalization']` and `variables['UpdateLocalization']`). This change affects multiple tasks, including:
  - Sending and downloading localization files for artifacts. (`[build/azure-pipelines.ymlL60-R68](diffhunk://#diff-5324d0d190cad8c6fa3025075de2f8f6bb002aca13c2850cb0b36af01af2ff8aL60-R68)`)
  - Downloading and using localization files. (`[build/azure-pipelines.ymlL75-R83](diffhunk://#diff-5324d0d190cad8c6fa3025075de2f8f6bb002aca13c2850cb0b36af01af2ff8aL75-R83)`)
  - Moving localization files one level up. (`[build/azure-pipelines.ymlL89-R97](diffhunk://#diff-5324d0d190cad8c6fa3025075de2f8f6bb002aca13c2850cb0b36af01af2ff8aL89-R97)`)
  - Archiving localization output for submission. (`[build/azure-pipelines.ymlL104-R112](diffhunk://#diff-5324d0d190cad8c6fa3025075de2f8f6bb002aca13c2850cb0b36af01af2ff8aL104-R112)`)
  - Publishing the `LocOutput` artifact. (`[build/azure-pipelines.ymlL209-R220](diffhunk://#diff-5324d0d190cad8c6fa3025075de2f8f6bb002aca13c2850cb0b36af01af2ff8aL209-R220)`)

### Artifact configuration update:
* Changed the `sbomPackageName` for the `LocOutput` artifact from `devhomegithubextension.locoutput` to `cmdpalgithubextension.locoutput`. (`[build/azure-pipelines.ymlL209-R220](diffhunk://#diff-5324d0d190cad8c6fa3025075de2f8f6bb002aca13c2850cb0b36af01af2ff8aL209-R220)`)