### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: [ "main", "dev" ]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/CmdPalGitHubExtension/security/code-scanning/1](https://github.com/microsoft/CmdPalGitHubExtension/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/CI.yml` at the workflow root (top level), so it applies to all jobs unless overridden.  
For this workflow, the minimal safe permission is:

- `contents: read`

Best single fix without changing functionality:
- Insert `permissions:` after the `on:` trigger block and before `jobs:`.
- Keep all existing jobs/steps unchanged.

No imports, methods, or external definitions are needed (YAML config change only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
