### PR TITLE
Improve copy command UX: keep palette open and update messaging

### DIFF
--- a/GitHubExtension/Controls/Commands/CopyCommand.cs
+++ b/GitHubExtension/Controls/Commands/CopyCommand.cs
@@ -26,7 +26,6 @@ internal sealed partial class CopyCommand : InvokableCommand
 
         ToastHelper.ShowSuccessToast(_resources.GetResource("Message_CopyCommand_Success"));
 
-        Thread.Sleep(1500); // Wait for the toast to show before dismissing the command
-        return CommandResult.Dismiss();
+        return CommandResult.KeepOpen();
     }
 }

--- a/GitHubExtension/Controls/Commands/LinkCommand.cs
+++ b/GitHubExtension/Controls/Commands/LinkCommand.cs
@@ -29,6 +29,6 @@ internal sealed partial class LinkCommand : InvokableCommand
     public override CommandResult Invoke()
     {
         Process.Start(new ProcessStartInfo(_htmlUrl) { UseShellExecute = true });
-        return CommandResult.KeepOpen();
+        return CommandResult.Dismiss();
     }
 }

--- a/GitHubExtension/Strings/en-US/Resources.resw
+++ b/GitHubExtension/Strings/en-US/Resources.resw
@@ -118,15 +118,15 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Commands_Copy_Source_Branch" xml:space="preserve">
-    <value>Source branch copied to clipboard</value>
+    <value>Copy source branch</value>
     <comment>Title for command to copy source branch of a pull request</comment>
   </data>
   <data name="Commands_Copy_Checkout" xml:space="preserve">
-    <value>Checkout command copied to clipboard</value>
+    <value>Copy checkout command</value>
     <comment>Title for copy checkout command</comment>
   </data>
   <data name="Commands_Copy" xml:space="preserve">
-    <value>Copied to clipboard</value>
+    <value>Copy</value>
     <comment>Title of Copy command, shown in pages menu options</comment>
   </data>
   <data name="Commands_Open_Link" xml:space="preserve">
@@ -350,15 +350,15 @@
     <comment>The command name for copying a URL</comment>
   </data>
   <data name="Commands_CopyIssueTitle" xml:space="preserve">
-    <value>Issue title copied to clipboard</value>
+    <value>Copy issue title</value>
     <comment>The command name for copying an issue title</comment>
   </data>
   <data name="Commands_CopyIssueNumber" xml:space="preserve">
-    <value>Issue number copied to clipboard</value>
+    <value>Copy issue number</value>
     <comment>Command name for copying an issue number</comment>
   </data>
   <data name="Commands_CopyPullRequestNumber" xml:space="preserve">
-    <value>Pull request number copied to clipboard</value>
+    <value>Copy pull request number</value>
     <comment>Name for the copy pull request number command</comment>
   </data>
   <data name="Pages_SaveSearch" xml:space="preserve">
@@ -366,7 +366,7 @@
     <comment>Title of SaveSearchPage</comment>
   </data>
   <data name="Commands_CopyPullRequestTitle" xml:space="preserve">
-    <value>Pull request title copied to clipboard</value>
+    <value>Copy pull request title</value>
     <comment>The name of the copy pull request title command</comment>
   </data>
   <data name="Forms_SaveSearchTemplateEditSearchActionTitle" xml:space="preserve">

--- a/GitHubExtension/Strings/en-US/Resources.resw
+++ b/GitHubExtension/Strings/en-US/Resources.resw
@@ -118,15 +118,15 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Commands_Copy_Source_Branch" xml:space="preserve">
-    <value>Copy source branch</value>
+    <value>Source branch copied to clipboard</value>
     <comment>Title for command to copy source branch of a pull request</comment>
   </data>
   <data name="Commands_Copy_Checkout" xml:space="preserve">
-    <value>Copy checkout command</value>
+    <value>Checkout command copied to clipboard</value>
     <comment>Title for copy checkout command</comment>
   </data>
   <data name="Commands_Copy" xml:space="preserve">
-    <value>Copy</value>
+    <value>Copied to clipboard</value>
     <comment>Title of Copy command, shown in pages menu options</comment>
   </data>
   <data name="Commands_Open_Link" xml:space="preserve">
@@ -350,15 +350,15 @@
     <comment>The command name for copying a URL</comment>
   </data>
   <data name="Commands_CopyIssueTitle" xml:space="preserve">
-    <value>Copy issue title</value>
+    <value>Issue title copied to clipboard</value>
     <comment>The command name for copying an issue title</comment>
   </data>
   <data name="Commands_CopyIssueNumber" xml:space="preserve">
-    <value>Copy issue number</value>
+    <value>Issue number copied to clipboard</value>
     <comment>Command name for copying an issue number</comment>
   </data>
   <data name="Commands_CopyPullRequestNumber" xml:space="preserve">
-    <value>Copy pull request number</value>
+    <value>Pull request number copied to clipboard</value>
     <comment>Name for the copy pull request number command</comment>
   </data>
   <data name="Pages_SaveSearch" xml:space="preserve">
@@ -366,7 +366,7 @@
     <comment>Title of SaveSearchPage</comment>
   </data>
   <data name="Commands_CopyPullRequestTitle" xml:space="preserve">
-    <value>Copy pull request title</value>
+    <value>Pull request title copied to clipboard</value>
     <comment>The name of the copy pull request title command</comment>
   </data>
   <data name="Forms_SaveSearchTemplateEditSearchActionTitle" xml:space="preserve">
@@ -390,7 +390,7 @@
     <comment>The placeholder for a name in the "Add a query" form</comment>
   </data>
   <data name="Message_CopyCommand_Success" xml:space="preserve">
-    <value>Copied!</value>
+    <value>Copied to clipboard!</value>
     <comment>The message displayed to a user when a value is copied successfully</comment>
   </data>
   <data name="Commands_Copy_GitCheckoutCommand" xml:space="preserve">

--- a/GitHubExtension/Strings/en-US/Resources.resw
+++ b/GitHubExtension/Strings/en-US/Resources.resw
@@ -346,7 +346,7 @@
     <comment>The name of the SignOut command</comment>
   </data>
   <data name="Commands_CopyURL" xml:space="preserve">
-    <value>Copy URL</value>
+    <value>Link copied to clipboard</value>
     <comment>The command name for copying a URL</comment>
   </data>
   <data name="Commands_CopyIssueTitle" xml:space="preserve">


### PR DESCRIPTION
This PR improves the user experience for copy and link commands in the "More" context menu (accessible from search result items like "Mentions me", "Assigned to me", etc.).

This PR address internal a11y bugs: 58664809, 58664669 & 58664445

**Changes**
- CopyCommand: Changed `CommandResult.Dismiss()` to `CommandResult.KeepOpen()` so the palette stays open after copying, allowing users to perform multiple actions without re-navigating. Removed the `Thread.Sleep(1500)` that was only needed to delay the dismiss.
- LinkCommand: Changed `CommandResult.KeepOpen()` to `CommandResult.Dismiss()` so the palette closes after opening a link in the browser, since the user's intent is to leave the palette.
- Resource strings: Updated copy command names to use confirmation-style messaging (e.g., "Link copied to clipboard", "Issue title copied to clipboard") to provide immediate feedback since the palette now remains open. Updated `Message_CopyCommand_Success` toast to "Copied to clipboard!".

