### PR TITLE
M2: Notifications (read + unread count)

### DIFF
--- a/GitHubExtension.Test/Controls/NotificationsPageTests.cs
+++ b/GitHubExtension.Test/Controls/NotificationsPageTests.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Controls;
+using GitHubExtension.Controls.Pages;
+using GitHubExtension.DataManager;
+using GitHubExtension.Helpers;
+using Moq;
+
+namespace GitHubExtension.Test.Controls;
+
+[TestClass]
+public class NotificationsPageTests
+{
+    private (Mock<INotificationsDataManager> DataManager, NotificationsMediator Mediator, Mock<IResources> Resources) CreateCommonMocks()
+    {
+        var dataManager = new Mock<INotificationsDataManager>();
+        var mediator = new NotificationsMediator();
+        var resources = new Mock<IResources>();
+        resources.Setup(x => x.GetResource(It.IsAny<string>(), null)).Returns("Mocked Resource");
+        return (dataManager, mediator, resources);
+    }
+
+    private static Mock<INotification> CreateNotification(string id, string title, string repo, bool unread)
+    {
+        var notification = new Mock<INotification>();
+        notification.Setup(x => x.Id).Returns(id);
+        notification.Setup(x => x.Title).Returns(title);
+        notification.Setup(x => x.RepositoryFullName).Returns(repo);
+        notification.Setup(x => x.HtmlUrl).Returns($"https://github.com/{repo}");
+        notification.Setup(x => x.Unread).Returns(unread);
+        return notification;
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void NotificationsPage_Create_Succeeds()
+    {
+        var (dataManager, mediator, resources) = CreateCommonMocks();
+        var page = new NotificationsPage(dataManager.Object, mediator, resources.Object);
+        Assert.IsNotNull(page);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void GetItems_ReturnsNotifications()
+    {
+        var (dataManager, mediator, resources) = CreateCommonMocks();
+        var notifications = new List<INotification>
+        {
+            CreateNotification("1", "First", "owner/repo1", true).Object,
+            CreateNotification("2", "Second", "owner/repo2", true).Object,
+        };
+        dataManager.Setup(x => x.GetNotificationsAsync(true)).ReturnsAsync(notifications);
+
+        var page = new NotificationsPage(dataManager.Object, mediator, resources.Object);
+        var items = page.GetItems();
+
+        Assert.AreEqual(2, items.Length);
+        Assert.AreEqual("First", items[0].Title);
+        Assert.AreEqual("Second", items[1].Title);
+        Assert.AreEqual(2, page.UnreadCount);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void GetItems_NoNotifications_ReturnsPlaceholder()
+    {
+        var (dataManager, mediator, resources) = CreateCommonMocks();
+        dataManager.Setup(x => x.GetNotificationsAsync(true)).ReturnsAsync(new List<INotification>());
+
+        var page = new NotificationsPage(dataManager.Object, mediator, resources.Object);
+        var items = page.GetItems();
+
+        Assert.AreEqual(1, items.Length);
+        Assert.AreEqual(0, page.UnreadCount);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public async Task RefreshUnreadCountAsync_UpdatesCount()
+    {
+        var (dataManager, mediator, resources) = CreateCommonMocks();
+        dataManager.Setup(x => x.GetUnreadCountAsync()).ReturnsAsync(5);
+
+        var page = new NotificationsPage(dataManager.Object, mediator, resources.Object);
+        await page.RefreshUnreadCountAsync();
+
+        Assert.AreEqual(5, page.UnreadCount);
+    }
+}

--- a/GitHubExtension.Test/Helpers/TestSetupHelpers.cs
+++ b/GitHubExtension.Test/Helpers/TestSetupHelpers.cs
@@ -8,6 +8,7 @@ using GitHubExtension.Controls;
 using GitHubExtension.Controls.Commands;
 using GitHubExtension.Controls.Forms;
 using GitHubExtension.Controls.Pages;
+using GitHubExtension.DataManager;
 using GitHubExtension.DataModel;
 using GitHubExtension.DataModel.Enums;
 using GitHubExtension.DeveloperIds;
@@ -170,6 +171,10 @@ public partial class TestHelpers
         var mockSignInForm = new Mock<SignInForm>(mockAuthenticationMediator, mockResources, mockDeveloperIdProvider, mockSignInCommand).Object;
         var signOutPage = new SignOutPage(mockResources, mockSignOutForm, mockSignOutCommand, mockAuthenticationMediator);
         var signInPage = new SignInPage(mockSignInForm, mockResources, mockSignInCommand, mockAuthenticationMediator);
-        return new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, mockDeveloperIdProvider, persistentDataManager, mockResources, searchPageFactory, savedSearchesMediator, mockAuthenticationMediator);
+        var notificationsMediator = new NotificationsMediator();
+        var mockNotificationsDataManager = new Mock<INotificationsDataManager>();
+        mockNotificationsDataManager.Setup(x => x.GetUnreadCountAsync()).ReturnsAsync(0);
+        var notificationsPage = new NotificationsPage(mockNotificationsDataManager.Object, notificationsMediator, mockResources);
+        return new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, notificationsPage, mockDeveloperIdProvider, persistentDataManager, mockResources, searchPageFactory, savedSearchesMediator, mockAuthenticationMediator, notificationsMediator);
     }
 }

--- a/GitHubExtension.Test/HelpersTests/NotificationHelperTests.cs
+++ b/GitHubExtension.Test/HelpersTests/NotificationHelperTests.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Helpers;
+
+namespace GitHubExtension.Test.HelpersTests;
+
+[TestClass]
+public class NotificationHelperTests
+{
+    [TestMethod]
+    [TestCategory("Unit")]
+    [DataRow("https://api.github.com/repos/octocat/hello/issues/42", "Issue", "https://github.com/octocat/hello", "https://github.com/octocat/hello/issues/42")]
+    [DataRow("https://api.github.com/repos/octocat/hello/pulls/7", "PullRequest", "https://github.com/octocat/hello", "https://github.com/octocat/hello/pull/7")]
+    [DataRow("https://api.github.com/repos/octocat/hello/commits/abc123", "Commit", "https://github.com/octocat/hello", "https://github.com/octocat/hello/commit/abc123")]
+    public void GetHtmlUrl_ConvertsApiUrlToBrowserUrl(string apiUrl, string type, string repoHtmlUrl, string expected)
+    {
+        var result = NotificationHelper.GetHtmlUrl(apiUrl, type, repoHtmlUrl);
+        Assert.AreEqual(expected, result);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void GetHtmlUrl_ReleaseFallsBackToRepositoryReleases()
+    {
+        var result = NotificationHelper.GetHtmlUrl("https://api.github.com/repos/octocat/hello/releases/99", "Release", "https://github.com/octocat/hello");
+        Assert.AreEqual("https://github.com/octocat/hello/releases", result);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void GetHtmlUrl_NullSubjectFallsBackToRepositoryUrl()
+    {
+        var result = NotificationHelper.GetHtmlUrl(null, "Discussion", "https://github.com/octocat/hello");
+        Assert.AreEqual("https://github.com/octocat/hello", result);
+    }
+}

--- a/GitHubExtension/Controls/Commands/LinkCommand.cs
+++ b/GitHubExtension/Controls/Commands/LinkCommand.cs
@@ -33,6 +33,13 @@ internal sealed partial class LinkCommand : InvokableCommand
         Icon = new IconInfo("\uE8A7");
     }
 
+    internal LinkCommand(INotification notification, IResources resources)
+    {
+        _htmlUrl = notification.HtmlUrl;
+        Name = resources.GetResource("Commands_Open_Link");
+        Icon = new IconInfo("\uE8A7");
+    }
+
     public override CommandResult Invoke()
     {
         Process.Start(new ProcessStartInfo(_htmlUrl) { UseShellExecute = true });

--- a/GitHubExtension/Controls/Commands/MarkNotificationReadCommand.cs
+++ b/GitHubExtension/Controls/Commands/MarkNotificationReadCommand.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Controls;
+using GitHubExtension.DataManager;
+using GitHubExtension.Helpers;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Serilog;
+
+namespace GitHubExtension.Controls.Commands;
+
+internal sealed partial class MarkNotificationReadCommand : InvokableCommand
+{
+    private static readonly ILogger _log = Log.ForContext("SourceContext", nameof(MarkNotificationReadCommand));
+
+    private readonly INotification _notification;
+    private readonly INotificationsDataManager _dataManager;
+    private readonly NotificationsMediator _mediator;
+    private readonly IResources _resources;
+
+    internal MarkNotificationReadCommand(INotification notification, INotificationsDataManager dataManager, NotificationsMediator mediator, IResources resources)
+    {
+        _notification = notification;
+        _dataManager = dataManager;
+        _mediator = mediator;
+        _resources = resources;
+        Name = resources.GetResource("Commands_MarkNotificationRead");
+        Icon = new IconInfo("\uE8FB");
+    }
+
+    public override CommandResult Invoke()
+    {
+        try
+        {
+            _dataManager.MarkNotificationAsReadAsync(_notification.Id).GetAwaiter().GetResult();
+            ToastHelper.ShowSuccessToast(_resources.GetResource("Message_MarkNotificationRead_Success"));
+            _mediator.NotifyNotificationsChanged();
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to mark notification as read.");
+            ToastHelper.ShowErrorToast(_resources.GetResource("Message_MarkNotificationRead_Error"));
+        }
+
+        return CommandResult.KeepOpen();
+    }
+}

--- a/GitHubExtension/Controls/INotification.cs
+++ b/GitHubExtension/Controls/INotification.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace GitHubExtension.Controls;
+
+public interface INotification
+{
+    string Id { get; }
+
+    string Title { get; }
+
+    string Reason { get; }
+
+    string RepositoryFullName { get; }
+
+    string HtmlUrl { get; }
+
+    string Type { get; }
+
+    bool Unread { get; }
+
+    DateTimeOffset UpdatedAt { get; }
+}

--- a/GitHubExtension/Controls/Notification.cs
+++ b/GitHubExtension/Controls/Notification.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace GitHubExtension.Controls;
+
+public sealed class Notification : INotification
+{
+    public string Id { get; init; } = string.Empty;
+
+    public string Title { get; init; } = string.Empty;
+
+    public string Reason { get; init; } = string.Empty;
+
+    public string RepositoryFullName { get; init; } = string.Empty;
+
+    public string HtmlUrl { get; init; } = string.Empty;
+
+    public string Type { get; init; } = string.Empty;
+
+    public bool Unread { get; init; }
+
+    public DateTimeOffset UpdatedAt { get; init; }
+}

--- a/GitHubExtension/Controls/NotificationsMediator.cs
+++ b/GitHubExtension/Controls/NotificationsMediator.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace GitHubExtension.Controls;
+
+public class NotificationsMediator
+{
+    public event EventHandler<object?>? NotificationsChanged;
+
+    public NotificationsMediator()
+    {
+    }
+
+    public void NotifyNotificationsChanged(object? args = null)
+    {
+        NotificationsChanged?.Invoke(this, args);
+    }
+}

--- a/GitHubExtension/Controls/Pages/NotificationsPage.cs
+++ b/GitHubExtension/Controls/Pages/NotificationsPage.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Controls.Commands;
+using GitHubExtension.DataManager;
+using GitHubExtension.Helpers;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Serilog;
+
+namespace GitHubExtension.Controls.Pages;
+
+public sealed partial class NotificationsPage : ListPage
+{
+    private readonly INotificationsDataManager _dataManager;
+    private readonly NotificationsMediator _mediator;
+    private readonly IResources _resources;
+    private readonly ILogger _log;
+
+    public int UnreadCount { get; private set; }
+
+    public NotificationsPage(INotificationsDataManager dataManager, NotificationsMediator mediator, IResources resources)
+    {
+        _dataManager = dataManager;
+        _mediator = mediator;
+        _resources = resources;
+        _log = Log.ForContext("SourceContext", $"Pages/{nameof(NotificationsPage)}");
+
+        Name = resources.GetResource("Pages_Notifications");
+        Icon = GitHubIcon.IconDictionary["Notifications"];
+
+        _mediator.NotificationsChanged += OnNotificationsChanged;
+    }
+
+    private void OnNotificationsChanged(object? sender, object? args)
+    {
+        RaiseItemsChanged(0);
+    }
+
+    public override IListItem[] GetItems() => DoGetItems().GetAwaiter().GetResult();
+
+    // Refreshes the unread count without rendering the list. Used to populate the
+    // top-level command subtitle without requiring the user to open the page.
+    public async Task RefreshUnreadCountAsync()
+    {
+        try
+        {
+            UnreadCount = await _dataManager.GetUnreadCountAsync();
+            _mediator.NotifyNotificationsChanged();
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to refresh unread notification count.");
+        }
+    }
+
+    private async Task<IListItem[]> DoGetItems()
+    {
+        try
+        {
+            var notifications = (await _dataManager.GetNotificationsAsync(true)).ToList();
+            UnreadCount = notifications.Count(n => n.Unread);
+
+            if (notifications.Count == 0)
+            {
+                return new IListItem[]
+                {
+                    new ListItem(new NoOpCommand())
+                    {
+                        Title = _resources.GetResource("Pages_Notifications_None"),
+                        Icon = GitHubIcon.IconDictionary["Notifications"],
+                    },
+                };
+            }
+
+            return notifications.Select(GetListItem).ToArray();
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to load notifications.");
+            return new IListItem[]
+            {
+                new ListItem(new NoOpCommand())
+                {
+                    Title = _resources.GetResource("Pages_Error_Title"),
+                    Details = new Details()
+                    {
+                        Title = ex.Message,
+                        Body = string.IsNullOrEmpty(ex.StackTrace) ? "There is no stack trace for the error." : ex.StackTrace,
+                    },
+                },
+            };
+        }
+    }
+
+    private ListItem GetListItem(INotification notification)
+    {
+        return new ListItem(new LinkCommand(notification, _resources))
+        {
+            Title = notification.Title,
+            Icon = GitHubIcon.IconDictionary["Notifications"],
+            Subtitle = notification.RepositoryFullName,
+            MoreCommands = new CommandContextItem[]
+            {
+                new(new MarkNotificationReadCommand(notification, _dataManager, _mediator, _resources)),
+                new(new CopyCommand(notification.HtmlUrl, $"{_resources.GetResource("Commands_CopyURL")}", _resources)),
+            },
+        };
+    }
+}

--- a/GitHubExtension/DataManager/Data/NotificationsDataManager.cs
+++ b/GitHubExtension/DataManager/Data/NotificationsDataManager.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using GitHubExtension.Client;
+using GitHubExtension.Controls;
+using GitHubExtension.Helpers;
+using Octokit;
+using Serilog;
+
+namespace GitHubExtension.DataManager.Data;
+
+public sealed class NotificationsDataManager : INotificationsDataManager
+{
+    private static readonly Lazy<ILogger> _logger = new(() => Serilog.Log.ForContext("SourceContext", nameof(NotificationsDataManager)));
+
+    private static readonly ILogger _log = _logger.Value;
+
+    private readonly GitHubClientProvider _gitHubClientProvider;
+
+    public NotificationsDataManager(GitHubClientProvider gitHubClientProvider)
+    {
+        _gitHubClientProvider = gitHubClientProvider;
+    }
+
+    public async Task<IEnumerable<INotification>> GetNotificationsAsync(bool onlyUnread = true)
+    {
+        var client = await _gitHubClientProvider.GetClientForLoggedInDeveloper(false);
+
+        var request = new NotificationsRequest { All = !onlyUnread };
+        var notifications = await client.Activity.Notifications.GetAllForCurrent(request);
+
+        _log.Debug($"Retrieved {notifications.Count} notifications (onlyUnread: {onlyUnread}).");
+
+        return notifications.Select(ToNotification).ToList();
+    }
+
+    public async Task MarkNotificationAsReadAsync(string id)
+    {
+        if (!int.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var threadId))
+        {
+            _log.Warning($"Unable to parse notification id '{id}' as a thread id.");
+            return;
+        }
+
+        var client = await _gitHubClientProvider.GetClientForLoggedInDeveloper(false);
+        await client.Activity.Notifications.MarkAsRead(threadId);
+        _log.Information($"Marked notification {threadId} as read.");
+    }
+
+    public async Task<int> GetUnreadCountAsync()
+    {
+        var notifications = await GetNotificationsAsync(true);
+        return notifications.Count(n => n.Unread);
+    }
+
+    private static Controls.Notification ToNotification(Octokit.Notification notification)
+    {
+        var repositoryFullName = notification.Repository?.FullName ?? string.Empty;
+        var repositoryHtmlUrl = notification.Repository?.HtmlUrl ?? string.Empty;
+
+        return new Controls.Notification
+        {
+            Id = notification.Id ?? string.Empty,
+            Title = notification.Subject?.Title ?? string.Empty,
+            Reason = notification.Reason ?? string.Empty,
+            RepositoryFullName = repositoryFullName,
+            Type = notification.Subject?.Type ?? string.Empty,
+            HtmlUrl = NotificationHelper.GetHtmlUrl(notification.Subject?.Url, notification.Subject?.Type, repositoryHtmlUrl),
+            Unread = notification.Unread,
+            UpdatedAt = ParseDate(notification.UpdatedAt),
+        };
+    }
+
+    private static DateTimeOffset ParseDate(string? value)
+    {
+        if (!string.IsNullOrEmpty(value) &&
+            DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsed))
+        {
+            return parsed;
+        }
+
+        return DateTimeOffset.MinValue;
+    }
+}

--- a/GitHubExtension/DataManager/INotificationsDataManager.cs
+++ b/GitHubExtension/DataManager/INotificationsDataManager.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Controls;
+
+namespace GitHubExtension.DataManager;
+
+public interface INotificationsDataManager
+{
+    // Fetches notifications for the signed-in user. When onlyUnread is true only
+    // unread notifications are returned (GitHub's default behavior).
+    Task<IEnumerable<INotification>> GetNotificationsAsync(bool onlyUnread = true);
+
+    // Marks a single notification thread as read.
+    Task MarkNotificationAsReadAsync(string id);
+
+    // Returns the number of unread notifications.
+    Task<int> GetUnreadCountAsync();
+}

--- a/GitHubExtension/GitHubExtensionCommandsProvider.cs
+++ b/GitHubExtension/GitHubExtensionCommandsProvider.cs
@@ -17,33 +17,39 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
     private readonly SavedSearchesPage _savedSearchesPage;
     private readonly SignOutPage _signOutPage;
     private readonly SignInPage _signInPage;
+    private readonly NotificationsPage _notificationsPage;
     private readonly IDeveloperIdProvider _developerIdProvider;
     private readonly ISearchRepository _persistentDataManager;
     private readonly ISearchPageFactory _searchPageFactory;
     private readonly IResources _resources;
     private readonly SavedSearchesMediator _savedSearchesMediator;
     private readonly AuthenticationMediator _authenticationMediator;
+    private readonly NotificationsMediator _notificationsMediator;
 
     public GitHubExtensionCommandsProvider(
         SavedSearchesPage savedSearchesPage,
         SignOutPage signOutPage,
         SignInPage signInPage,
+        NotificationsPage notificationsPage,
         IDeveloperIdProvider developerIdProvider,
         ISearchRepository persistentDataManager,
         IResources resources,
         ISearchPageFactory searchPageFactory,
         SavedSearchesMediator savedSearchesMediator,
-        AuthenticationMediator authenticationMediator)
+        AuthenticationMediator authenticationMediator,
+        NotificationsMediator notificationsMediator)
     {
         _savedSearchesPage = savedSearchesPage;
         _signOutPage = signOutPage;
         _signInPage = signInPage;
+        _notificationsPage = notificationsPage;
         _developerIdProvider = developerIdProvider;
         _persistentDataManager = persistentDataManager;
         _resources = resources;
         _searchPageFactory = searchPageFactory;
         _savedSearchesMediator = savedSearchesMediator;
         _authenticationMediator = authenticationMediator;
+        _notificationsMediator = notificationsMediator;
 
         DisplayName = _resources.GetResource("ExtensionTitle");
 
@@ -51,10 +57,17 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
         _authenticationMediator.SignOutAction += OnSignInStatusChanged;
         _savedSearchesMediator.SearchSaved += OnSearchSaved;
         _savedSearchesMediator.SearchRemoved += OnSearchRemoved;
+        _notificationsMediator.NotificationsChanged += OnNotificationsChanged;
 
         // This async method raises the RaiseItemsChanged event to update the top-level commands
         // So it is safe if we let it run asynchronously as "fire and forget"
         _ = UpdateSignInStatus(_developerIdProvider.IsSignedIn());
+    }
+
+    private void OnNotificationsChanged(object? sender, object? args)
+    {
+        // Refreshes the top-level command subtitle when the unread count changes.
+        RaiseItemsChanged(0);
     }
 
     private void OnSearchRemoved(object? sender, SavedSearchRemovedEventArgs args)
@@ -92,12 +105,26 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
         var commands = GetTopLevelSearchCommands().GetAwaiter().GetResult().ToList();
         var defaultCommands = new List<CommandItem>
         {
+            BuildNotificationsCommandItem(),
             new(_savedSearchesPage),
             new(_signOutPage),
         };
 
         commands.AddRange(defaultCommands);
         return commands.ToArray();
+    }
+
+    private CommandItem BuildNotificationsCommandItem()
+    {
+        var subtitle = _notificationsPage.UnreadCount > 0
+            ? string.Format(System.Globalization.CultureInfo.CurrentCulture, _resources.GetResource("CommandsProvider_Notifications_UnreadCount"), _notificationsPage.UnreadCount)
+            : _resources.GetResource("CommandsProvider_Notifications_NoUnread");
+
+        return new CommandItem(_notificationsPage)
+        {
+            Title = _resources.GetResource("CommandsProvider_NotificationsCommandName"),
+            Subtitle = subtitle,
+        };
     }
 
     public async Task UpdateSignInStatus(bool isSignedIn)
@@ -143,6 +170,14 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
         }
 
         UpdateTopLevelCommands();
+
+        if (_isSignedIn)
+        {
+            // Populate the unread count for the top-level Notifications subtitle
+            // without requiring the user to open the page. This refreshes on
+            // sign-in (event-driven), not on a polling loop.
+            _ = _notificationsPage.RefreshUnreadCountAsync();
+        }
     }
 
     private void OnSignInStatusChanged(object? sender, SignInStatusChangedEventArgs e)
@@ -180,6 +215,7 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
                 _authenticationMediator.SignOutAction -= OnSignInStatusChanged;
                 _savedSearchesMediator.SearchSaved -= OnSearchSaved;
                 _savedSearchesMediator.SearchRemoved -= OnSearchRemoved;
+                _notificationsMediator.NotificationsChanged -= OnNotificationsChanged;
             }
 
             _disposed = true;

--- a/GitHubExtension/Helpers/GitHubIcon.cs
+++ b/GitHubExtension/Helpers/GitHubIcon.cs
@@ -24,6 +24,8 @@ public static class GitHubIcon
                 { "Search", new IconInfo("\ue721") },
                 { "repo", new IconInfo("\uE8F1") },
                 { "Repositories", new IconInfo("\uE8F1") },
+                { "notification", new IconInfo("\uEA8F") },
+                { "Notifications", new IconInfo("\uEA8F") },
             };
     }
 

--- a/GitHubExtension/Helpers/NotificationHelper.cs
+++ b/GitHubExtension/Helpers/NotificationHelper.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace GitHubExtension.Helpers;
+
+public static class NotificationHelper
+{
+    // Converts a notification subject API URL (e.g.
+    // https://api.github.com/repos/owner/repo/issues/1) into the equivalent
+    // browser URL (https://github.com/owner/repo/issues/1). When the subject
+    // does not map cleanly to a browsable page, falls back to the repository URL.
+    public static string GetHtmlUrl(string? subjectApiUrl, string? subjectType, string repositoryHtmlUrl)
+    {
+        if (string.IsNullOrEmpty(subjectApiUrl))
+        {
+            return repositoryHtmlUrl;
+        }
+
+        // Releases expose an internal id in the API URL that does not map to a
+        // browsable tag URL, so link to the repository releases page instead.
+        if (string.Equals(subjectType, "Release", StringComparison.OrdinalIgnoreCase))
+        {
+            return string.IsNullOrEmpty(repositoryHtmlUrl) ? subjectApiUrl : $"{repositoryHtmlUrl}/releases";
+        }
+
+        var htmlUrl = subjectApiUrl
+            .Replace("https://api.github.com/repos/", "https://github.com/", StringComparison.OrdinalIgnoreCase)
+            .Replace("/api/v3/repos/", "/", StringComparison.OrdinalIgnoreCase);
+
+        // The REST API uses plural resource segments that differ from the web UI.
+        htmlUrl = htmlUrl
+            .Replace("/pulls/", "/pull/", StringComparison.Ordinal)
+            .Replace("/commits/", "/commit/", StringComparison.Ordinal);
+
+        return htmlUrl;
+    }
+}

--- a/GitHubExtension/Program.cs
+++ b/GitHubExtension/Program.cs
@@ -131,6 +131,10 @@ public class Program
         using var cacheDataManager = new CacheDataManagerFacade(cacheManager, gitHubDataManager, decoratorFactory);
 
         var savedSearchesMediator = new SavedSearchesMediator();
+        var notificationsMediator = new NotificationsMediator();
+
+        var notificationsDataManager = new NotificationsDataManager(gitHubClientProvider);
+        var notificationsPage = new NotificationsPage(notificationsDataManager, notificationsMediator, resources);
 
         var searchPageFactory = new SearchPageFactory(cacheDataManager, searchRepository, resources, savedSearchesMediator);
 
@@ -146,7 +150,7 @@ public class Program
         using var signInForm = new SignInForm(authenticationMediator, resources, developerIdProvider, signInCommand);
         using var signInPage = new SignInPage(signInForm, resources, signInCommand, authenticationMediator);
 
-        using var commandProvider = new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, developerIdProvider, searchRepository, resources, searchPageFactory, savedSearchesMediator, authenticationMediator);
+        using var commandProvider = new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, notificationsPage, developerIdProvider, searchRepository, resources, searchPageFactory, savedSearchesMediator, authenticationMediator, notificationsMediator);
         var extensionInstance = new GitHubExtension(extensionDisposedEvent, commandProvider);
 
         // We are instantiating an extension instance once above, and returning it every time the callback in RegisterExtension below is called.

--- a/GitHubExtension/Strings/en-US/Resources.resw
+++ b/GitHubExtension/Strings/en-US/Resources.resw
@@ -329,6 +329,38 @@
     <value>My latest repositories</value>
     <comment>Title for search "user:{login} sort:updated-desc type:repository"</comment>
   </data>
+  <data name="CommandsProvider_NotificationsCommandName" xml:space="preserve">
+    <value>Notifications</value>
+    <comment>Title for the top-level Notifications command</comment>
+  </data>
+  <data name="CommandsProvider_Notifications_UnreadCount" xml:space="preserve">
+    <value>{0} unread</value>
+    <comment>Subtitle for the Notifications command showing the unread count. {0} is the number of unread notifications</comment>
+  </data>
+  <data name="CommandsProvider_Notifications_NoUnread" xml:space="preserve">
+    <value>No unread notifications</value>
+    <comment>Subtitle for the Notifications command when there are no unread notifications</comment>
+  </data>
+  <data name="Pages_Notifications" xml:space="preserve">
+    <value>Notifications</value>
+    <comment>Title of the notifications list page</comment>
+  </data>
+  <data name="Pages_Notifications_None" xml:space="preserve">
+    <value>No unread notifications</value>
+    <comment>Shown when there are no unread notifications</comment>
+  </data>
+  <data name="Commands_MarkNotificationRead" xml:space="preserve">
+    <value>Mark as read</value>
+    <comment>Command name for marking a notification as read</comment>
+  </data>
+  <data name="Message_MarkNotificationRead_Success" xml:space="preserve">
+    <value>Notification marked as read</value>
+    <comment>Toast shown after a notification is marked as read</comment>
+  </data>
+  <data name="Message_MarkNotificationRead_Error" xml:space="preserve">
+    <value>Failed to mark notification as read</value>
+    <comment>Toast shown when marking a notification as read fails</comment>
+  </data>
   <data name="ExtensionTitle" xml:space="preserve">
     <value>GitHub Extension (Preview)</value>
     <comment>Title for the extension</comment>


### PR DESCRIPTION
## Milestone 2 - Notifications (read + counts)

Stacked on M1 (targets `mjolley/cmdpal-github-extension-plan`). Adds GitHub notifications support to the Command Palette extension.

### Delivered
- **Notifications list page** - `NotificationsPage` lists the signed-in user's unread notifications. Each item opens in the browser and offers **Mark as read** and **Copy URL** actions.
- **Top-level Notifications command** - subtitle shows the unread count (the menu-bar "unread" reinterpretation from the roadmap). The count refreshes on sign-in and whenever notifications change, driven by a `NotificationsMediator` event - no polling loop.
- **Live-fetch data path** - `INotificationsDataManager` / `NotificationsDataManager` backed by the GitHub Activity API (`Activity.Notifications`), kept separate from the search-keyed SQLite cache since notifications do not fit that model.
- **Subject-URL to browser-URL helper** - converts notification subject API URLs (issues, pulls, commits) to browsable URLs, with sensible fallbacks for releases and discussions.

### Verification
- Built x64 Debug.
- Full test suite: 172/172 passing (9 new tests covering the page, unread-count refresh, empty state, and the URL helper).

Part of the stacked milestone series toward RayCast feature parity.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
