### PR TITLE
M3: Write actions on issues/PRs (+ mutation infrastructure)

### DIFF
--- a/GitHubExtension.Test/Controls/MutationCommandsFactoryTests.cs
+++ b/GitHubExtension.Test/Controls/MutationCommandsFactoryTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Controls;
+using GitHubExtension.Controls.Commands;
+using GitHubExtension.DataManager;
+using GitHubExtension.Helpers;
+using Moq;
+
+namespace GitHubExtension.Test.Controls;
+
+[TestClass]
+public class MutationCommandsFactoryTests
+{
+    private static (MutationCommandsFactory Factory, Mock<IGitHubMutationManager> Manager, MutationMediator Mediator) CreateFactory()
+    {
+        var manager = new Mock<IGitHubMutationManager>();
+        var mediator = new MutationMediator();
+        var resources = new Mock<IResources>();
+        resources.Setup(x => x.GetResource(It.IsAny<string>(), null)).Returns<string, object>((key, _) => key);
+        var factory = new MutationCommandsFactory(manager.Object, mediator, resources.Object);
+        return (factory, manager, mediator);
+    }
+
+    private static Mock<IIssue> CreateIssue(string state)
+    {
+        var issue = new Mock<IIssue>();
+        issue.Setup(x => x.State).Returns(state);
+        issue.Setup(x => x.HtmlUrl).Returns("https://github.com/owner/repo/issues/1");
+        issue.Setup(x => x.Number).Returns(1);
+        issue.Setup(x => x.Title).Returns("Title");
+        return issue;
+    }
+
+    private static Mock<IPullRequest> CreatePullRequest(string state)
+    {
+        var pr = new Mock<IPullRequest>();
+        pr.Setup(x => x.State).Returns(state);
+        pr.Setup(x => x.HtmlUrl).Returns("https://github.com/owner/repo/pull/2");
+        pr.Setup(x => x.Number).Returns(2);
+        pr.Setup(x => x.Title).Returns("Title");
+        pr.Setup(x => x.SourceBranch).Returns("feature");
+        return pr;
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void GetIssueCommands_OpenIssue_ReturnsCloseCommand()
+    {
+        var (factory, _, _) = CreateFactory();
+        var commands = factory.GetIssueCommands(CreateIssue("Open").Object).ToList();
+
+        Assert.AreEqual(1, commands.Count);
+        Assert.AreEqual("Commands_CloseIssue", commands[0].Command!.Name);
+        Assert.IsTrue(commands[0].IsCritical);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void GetIssueCommands_ClosedIssue_ReturnsReopenCommand()
+    {
+        var (factory, _, _) = CreateFactory();
+        var commands = factory.GetIssueCommands(CreateIssue("Closed").Object).ToList();
+
+        Assert.AreEqual(1, commands.Count);
+        Assert.AreEqual("Commands_ReopenIssue", commands[0].Command!.Name);
+        Assert.IsFalse(commands[0].IsCritical);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void GetPullRequestCommands_OpenPullRequest_ReturnsMergeAndCloseCommands()
+    {
+        var (factory, _, _) = CreateFactory();
+        var commands = factory.GetPullRequestCommands(CreatePullRequest("Open").Object).ToList();
+
+        Assert.AreEqual(2, commands.Count);
+        Assert.AreEqual("Commands_MergePullRequest", commands[0].Command!.Name);
+        Assert.AreEqual("Commands_ClosePullRequest", commands[1].Command!.Name);
+        Assert.IsTrue(commands[0].IsCritical);
+        Assert.IsTrue(commands[1].IsCritical);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void GetPullRequestCommands_ClosedPullRequest_ReturnsReopenCommand()
+    {
+        var (factory, _, _) = CreateFactory();
+        var commands = factory.GetPullRequestCommands(CreatePullRequest("Closed").Object).ToList();
+
+        Assert.AreEqual(1, commands.Count);
+        Assert.AreEqual("Commands_ReopenPullRequest", commands[0].Command!.Name);
+        Assert.IsFalse(commands[0].IsCritical);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void MergeCommand_Invoke_DefersToConfirmationWithoutCallingManager()
+    {
+        var (factory, manager, _) = CreateFactory();
+        var pr = CreatePullRequest("Open");
+
+        var commands = factory.GetPullRequestCommands(pr.Object).ToList();
+        var merge = (Microsoft.CommandPalette.Extensions.Toolkit.InvokableCommand)commands[0].Command!;
+        var result = merge.Invoke();
+
+        Assert.IsNotNull(result);
+        manager.Verify(x => x.MergePullRequestAsync(It.IsAny<IPullRequest>()), Times.Never);
+    }
+}

--- a/GitHubExtension.Test/Controls/SearchPagesTests.cs
+++ b/GitHubExtension.Test/Controls/SearchPagesTests.cs
@@ -4,7 +4,9 @@
 
 using System.Net;
 using GitHubExtension.Controls;
+using GitHubExtension.Controls.Commands;
 using GitHubExtension.Controls.Pages;
+using GitHubExtension.DataManager;
 using GitHubExtension.DataModel.Enums;
 using GitHubExtension.Helpers;
 using Moq;
@@ -15,6 +17,14 @@ namespace GitHubExtension.Test.Controls;
 [TestClass]
 public class SearchPagesTests
 {
+    private static (MutationCommandsFactory Factory, MutationMediator Mediator) CreateMutationDeps(Mock<IResources> resources)
+    {
+        var mutationManager = new Mock<IGitHubMutationManager>();
+        var mediator = new MutationMediator();
+        var factory = new MutationCommandsFactory(mutationManager.Object, mediator, resources.Object);
+        return (factory, mediator);
+    }
+
     private (Mock<ICacheDataManager> CacheDataManager, Mock<IResources> Resources, Mock<ISearch> Search) CreateCommonMocks(SearchType type, string searchString = "test search string")
     {
         var cacheDataManager = new Mock<ICacheDataManager>();
@@ -33,11 +43,12 @@ public class SearchPagesTests
     public void SearchPagesCreate_CreatesPagesForBothTypes()
     {
         var (cacheDataManager, resources, search) = CreateCommonMocks(SearchType.Issues, "test search string is:pr");
-        var issuesSearchPage = new IssuesSearchPage(search.Object, cacheDataManager.Object, resources.Object);
+        var (mutationFactory, mutationMediator) = CreateMutationDeps(resources);
+        var issuesSearchPage = new IssuesSearchPage(search.Object, cacheDataManager.Object, resources.Object, mutationFactory, mutationMediator);
         Assert.IsNotNull(issuesSearchPage);
 
         search.Setup(x => x.Type).Returns(SearchType.PullRequests);
-        var pullRequestsSearchPage = new PullRequestsSearchPage(search.Object, cacheDataManager.Object, resources.Object);
+        var pullRequestsSearchPage = new PullRequestsSearchPage(search.Object, cacheDataManager.Object, resources.Object, mutationFactory, mutationMediator);
         Assert.IsNotNull(pullRequestsSearchPage);
 
         search.Setup(x => x.Type).Returns(SearchType.Repositories);
@@ -82,7 +93,8 @@ public class SearchPagesTests
 
         if (type == SearchType.PullRequests)
         {
-            var page = new PullRequestsSearchPage(search.Object, cacheDataManager.Object, resources.Object);
+            var (mutationFactory, mutationMediator) = CreateMutationDeps(resources);
+            var page = new PullRequestsSearchPage(search.Object, cacheDataManager.Object, resources.Object, mutationFactory, mutationMediator);
             var pull1 = new Mock<IPullRequest>();
             var pull2 = new Mock<IPullRequest>();
             pull1.Setup(x => x.Title).Returns("Title1");
@@ -103,7 +115,8 @@ public class SearchPagesTests
         }
         else
         {
-            var page = new IssuesSearchPage(search.Object, cacheDataManager.Object, resources.Object);
+            var (mutationFactory, mutationMediator) = CreateMutationDeps(resources);
+            var page = new IssuesSearchPage(search.Object, cacheDataManager.Object, resources.Object, mutationFactory, mutationMediator);
             var issue1 = new Mock<IIssue>();
             var issue2 = new Mock<IIssue>();
             issue1.Setup(x => x.Title).Returns("Title1");
@@ -129,7 +142,8 @@ public class SearchPagesTests
         var (cacheDataManager, resources, search) = CreateCommonMocks(SearchType.PullRequests, "test search string is:pr");
         resources.Setup(x => x.GetResource("Pages_Error_Title", null)).Returns("Error fetching items");
 
-        var pullRequestsSearchPage = new PullRequestsSearchPage(search.Object, cacheDataManager.Object, resources.Object);
+        var (mutationFactory, mutationMediator) = CreateMutationDeps(resources);
+        var pullRequestsSearchPage = new PullRequestsSearchPage(search.Object, cacheDataManager.Object, resources.Object, mutationFactory, mutationMediator);
 
         var mockResponse = new Mock<IResponse>();
         mockResponse.SetupGet(r => r.StatusCode).Returns(HttpStatusCode.Forbidden);

--- a/GitHubExtension.Test/Controls/TopLevelSearchesTest.cs
+++ b/GitHubExtension.Test/Controls/TopLevelSearchesTest.cs
@@ -3,8 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using GitHubExtension.Controls;
+using GitHubExtension.Controls.Commands;
 using GitHubExtension.Controls.Forms;
 using GitHubExtension.Controls.Pages;
+using GitHubExtension.DataManager;
 using GitHubExtension.DataModel;
 using GitHubExtension.Helpers;
 using GitHubExtension.PersistentData;
@@ -110,7 +112,10 @@ public class TopLevelSearchesTest
         {
             var mockDeveloperIdProvider = TestHelpers.CreateMockDeveloperIdProvider();
             var mockCacheDataManager = new Mock<ICacheDataManager>().Object;
-            var searchPageFactory = new SearchPageFactory(mockCacheDataManager, persistentDataManager, resources, mediator);
+            var mutationManager = new Mock<IGitHubMutationManager>().Object;
+            var mutationMediator = new MutationMediator();
+            var mutationCommandsFactory = new MutationCommandsFactory(mutationManager, mutationMediator, resources);
+            var searchPageFactory = new SearchPageFactory(mockCacheDataManager, persistentDataManager, resources, mediator, mutationCommandsFactory, mutationMediator);
 
             var addSearchForm = new SaveSearchForm(persistentDataManager, resources, mediator);
 

--- a/GitHubExtension/Controls/Commands/ConfirmedCommand.cs
+++ b/GitHubExtension/Controls/Commands/ConfirmedCommand.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace GitHubExtension.Controls.Commands;
+
+// Wraps a destructive command in a confirmation prompt. When the user confirms,
+// the inner command runs. Used for irreversible actions such as merging or
+// closing.
+internal sealed partial class ConfirmedCommand : InvokableCommand
+{
+    private readonly InvokableCommand _innerCommand;
+    private readonly string _confirmTitle;
+    private readonly string _confirmDescription;
+
+    internal ConfirmedCommand(InvokableCommand innerCommand, string name, IconInfo icon, string confirmTitle, string confirmDescription)
+    {
+        _innerCommand = innerCommand;
+        _confirmTitle = confirmTitle;
+        _confirmDescription = confirmDescription;
+        Name = name;
+        Icon = icon;
+    }
+
+    public override CommandResult Invoke()
+    {
+        return CommandResult.Confirm(new ConfirmationArgs
+        {
+            Title = _confirmTitle,
+            Description = _confirmDescription,
+            PrimaryCommand = _innerCommand,
+            IsPrimaryCommandCritical = true,
+        });
+    }
+}

--- a/GitHubExtension/Controls/Commands/GitHubMutationCommand.cs
+++ b/GitHubExtension/Controls/Commands/GitHubMutationCommand.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Helpers;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Serilog;
+
+namespace GitHubExtension.Controls.Commands;
+
+// Runs a single write action against GitHub, showing a success or error toast
+// and notifying the mutation mediator so open surfaces can refresh. Non
+// destructive actions use this command directly; destructive actions wrap it
+// in a ConfirmedCommand.
+internal sealed partial class GitHubMutationCommand : InvokableCommand
+{
+    private static readonly ILogger _log = Log.ForContext("SourceContext", nameof(GitHubMutationCommand));
+
+    private readonly Func<Task> _mutation;
+    private readonly string _successMessage;
+    private readonly string _errorMessage;
+    private readonly MutationMediator _mediator;
+
+    internal GitHubMutationCommand(string name, IconInfo icon, Func<Task> mutation, string successMessage, string errorMessage, MutationMediator mediator)
+    {
+        Name = name;
+        Icon = icon;
+        _mutation = mutation;
+        _successMessage = successMessage;
+        _errorMessage = errorMessage;
+        _mediator = mediator;
+    }
+
+    public override CommandResult Invoke()
+    {
+        try
+        {
+            _mutation().GetAwaiter().GetResult();
+            ToastHelper.ShowSuccessToast(_successMessage);
+            _mediator.NotifyMutationCompleted();
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "GitHub write action failed.");
+            ToastHelper.ShowErrorToast(_errorMessage);
+        }
+
+        return CommandResult.KeepOpen();
+    }
+}

--- a/GitHubExtension/Controls/Commands/MutationCommandsFactory.cs
+++ b/GitHubExtension/Controls/Commands/MutationCommandsFactory.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.DataManager;
+using GitHubExtension.Helpers;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace GitHubExtension.Controls.Commands;
+
+// Builds the set of write-action context items for an issue or pull request.
+// The available actions depend on the item's current state (open vs closed).
+public sealed class MutationCommandsFactory
+{
+    private readonly IGitHubMutationManager _mutationManager;
+    private readonly MutationMediator _mediator;
+    private readonly IResources _resources;
+
+    private static readonly IconInfo CloseIcon = new("\uE711");
+    private static readonly IconInfo ReopenIcon = new("\uE72C");
+    private static readonly IconInfo MergeIcon = new("\uE8FB");
+
+    public MutationCommandsFactory(IGitHubMutationManager mutationManager, MutationMediator mediator, IResources resources)
+    {
+        _mutationManager = mutationManager;
+        _mediator = mediator;
+        _resources = resources;
+    }
+
+    private static bool IsOpen(IIssue issue) => string.Equals(issue.State, "Open", StringComparison.OrdinalIgnoreCase);
+
+    public IEnumerable<CommandContextItem> GetIssueCommands(IIssue issue)
+    {
+        var items = new List<CommandContextItem>();
+
+        if (IsOpen(issue))
+        {
+            var close = new GitHubMutationCommand(
+                _resources.GetResource("Commands_CloseIssue"),
+                CloseIcon,
+                () => _mutationManager.CloseIssueAsync(issue),
+                _resources.GetResource("Message_CloseIssue_Success"),
+                _resources.GetResource("Message_CloseIssue_Error"),
+                _mediator);
+
+            var confirmed = new ConfirmedCommand(
+                close,
+                _resources.GetResource("Commands_CloseIssue"),
+                CloseIcon,
+                _resources.GetResource("Confirm_CloseIssue_Title"),
+                _resources.GetResource("Confirm_CloseIssue_Description"));
+
+            items.Add(new CommandContextItem(confirmed) { IsCritical = true });
+        }
+        else
+        {
+            var reopen = new GitHubMutationCommand(
+                _resources.GetResource("Commands_ReopenIssue"),
+                ReopenIcon,
+                () => _mutationManager.ReopenIssueAsync(issue),
+                _resources.GetResource("Message_ReopenIssue_Success"),
+                _resources.GetResource("Message_ReopenIssue_Error"),
+                _mediator);
+
+            items.Add(new CommandContextItem(reopen));
+        }
+
+        return items;
+    }
+
+    public IEnumerable<CommandContextItem> GetPullRequestCommands(IPullRequest pullRequest)
+    {
+        var items = new List<CommandContextItem>();
+
+        if (IsOpen(pullRequest))
+        {
+            var merge = new GitHubMutationCommand(
+                _resources.GetResource("Commands_MergePullRequest"),
+                MergeIcon,
+                () => _mutationManager.MergePullRequestAsync(pullRequest),
+                _resources.GetResource("Message_MergePullRequest_Success"),
+                _resources.GetResource("Message_MergePullRequest_Error"),
+                _mediator);
+
+            var confirmedMerge = new ConfirmedCommand(
+                merge,
+                _resources.GetResource("Commands_MergePullRequest"),
+                MergeIcon,
+                _resources.GetResource("Confirm_MergePullRequest_Title"),
+                _resources.GetResource("Confirm_MergePullRequest_Description"));
+
+            items.Add(new CommandContextItem(confirmedMerge) { IsCritical = true });
+
+            var close = new GitHubMutationCommand(
+                _resources.GetResource("Commands_ClosePullRequest"),
+                CloseIcon,
+                () => _mutationManager.ClosePullRequestAsync(pullRequest),
+                _resources.GetResource("Message_ClosePullRequest_Success"),
+                _resources.GetResource("Message_ClosePullRequest_Error"),
+                _mediator);
+
+            var confirmedClose = new ConfirmedCommand(
+                close,
+                _resources.GetResource("Commands_ClosePullRequest"),
+                CloseIcon,
+                _resources.GetResource("Confirm_ClosePullRequest_Title"),
+                _resources.GetResource("Confirm_ClosePullRequest_Description"));
+
+            items.Add(new CommandContextItem(confirmedClose) { IsCritical = true });
+        }
+        else
+        {
+            var reopen = new GitHubMutationCommand(
+                _resources.GetResource("Commands_ReopenPullRequest"),
+                ReopenIcon,
+                () => _mutationManager.ReopenPullRequestAsync(pullRequest),
+                _resources.GetResource("Message_ReopenPullRequest_Success"),
+                _resources.GetResource("Message_ReopenPullRequest_Error"),
+                _mediator);
+
+            items.Add(new CommandContextItem(reopen));
+        }
+
+        return items;
+    }
+}

--- a/GitHubExtension/Controls/IIssue.cs
+++ b/GitHubExtension/Controls/IIssue.cs
@@ -14,5 +14,7 @@ public interface IIssue
 
     string Body { get; }
 
+    string State { get; }
+
     IEnumerable<ILabel> Labels { get; }
 }

--- a/GitHubExtension/Controls/MutationMediator.cs
+++ b/GitHubExtension/Controls/MutationMediator.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Helpers;
+
+namespace GitHubExtension.Controls;
+
+// Raised after a write action (close/reopen/merge, etc.) completes so that
+// surfaces showing the mutated item can refresh. Uses a weak event source so
+// that transient pages that subscribe do not leak.
+public class MutationMediator
+{
+    private readonly WeakEventSource<EventArgs> _mutationCompletedSource = new();
+
+    public event EventHandler<EventArgs>? MutationCompleted
+    {
+        add => _mutationCompletedSource.Subscribe(value);
+        remove => _mutationCompletedSource.Unsubscribe(value);
+    }
+
+    public MutationMediator()
+    {
+    }
+
+    public void NotifyMutationCompleted()
+    {
+        _mutationCompletedSource.Raise(this, EventArgs.Empty);
+    }
+}

--- a/GitHubExtension/Controls/Pages/IssueMarkdownPage.cs
+++ b/GitHubExtension/Controls/Pages/IssueMarkdownPage.cs
@@ -15,21 +15,26 @@ internal sealed partial class IssueContentPage : ContentPage
     private readonly IIssue _issue;
     private readonly IResources _resources;
 
-    public IssueContentPage(IIssue issue, IResources resources)
+    public IssueContentPage(IIssue issue, IResources resources, MutationCommandsFactory? mutationCommandsFactory = null)
     {
         _resources = resources;
         Icon = GitHubIcon.IconDictionary["issue"];
         Name = _resources.GetResource("Pages_Markdown_Issue");
         _issue = issue;
-#pragma warning disable IDE0300 // Simplify collection initialization
-        Commands = new CommandContextItem[]
+        var commands = new List<CommandContextItem>
         {
             new(new LinkCommand(issue, resources)),
             new(new CopyCommand(issue.HtmlUrl, _resources.GetResource("Commands_CopyURL"), _resources)),
             new(new CopyCommand(issue.Title, _resources.GetResource("Commands_CopyIssueTitle"), _resources)),
             new(new CopyCommand(issue.Number.ToString(CultureInfo.InvariantCulture), _resources.GetResource("Commands_CopyIssueNumber"), _resources)),
         };
-#pragma warning restore IDE0300 // Simplify collection initialization
+
+        if (mutationCommandsFactory != null)
+        {
+            commands.AddRange(mutationCommandsFactory.GetIssueCommands(issue));
+        }
+
+        Commands = commands.ToArray();
     }
 
     public override IContent[] GetContent()

--- a/GitHubExtension/Controls/Pages/PullRequestMarkdownPage.cs
+++ b/GitHubExtension/Controls/Pages/PullRequestMarkdownPage.cs
@@ -15,22 +15,27 @@ internal sealed partial class PullRequestContentPage : ContentPage
     private readonly IPullRequest _pullRequest;
     private readonly IResources _resources;
 
-    public PullRequestContentPage(IPullRequest pullRequest, IResources resources)
+    public PullRequestContentPage(IPullRequest pullRequest, IResources resources, MutationCommandsFactory? mutationCommandsFactory = null)
     {
         _resources = resources;
 
         Icon = GitHubIcon.IconDictionary["pr"];
         Name = _resources.GetResource("Pages_Markdown_PullRequest");
         _pullRequest = pullRequest;
-#pragma warning disable IDE0300 // Simplify collection initialization
-        Commands = new CommandContextItem[]
+        var commands = new List<CommandContextItem>
         {
             new(new LinkCommand(pullRequest, resources)),
             new(new CopyCommand(pullRequest.HtmlUrl, _resources.GetResource("Commands_CopyURL"), _resources)),
             new(new CopyCommand(pullRequest.Title, _resources.GetResource("Commands_CopyPullRequestTitle"), _resources)),
             new(new CopyCommand(pullRequest.Number.ToString(CultureInfo.InvariantCulture), _resources.GetResource("Commands_CopyPullRequestNumber"), _resources)),
         };
-#pragma warning restore IDE0300 // Simplify collection initialization
+
+        if (mutationCommandsFactory != null)
+        {
+            commands.AddRange(mutationCommandsFactory.GetPullRequestCommands(pullRequest));
+        }
+
+        Commands = commands.ToArray();
     }
 
     public override IContent[] GetContent()

--- a/GitHubExtension/Controls/Pages/SearchPages/CombinedSearchPage.cs
+++ b/GitHubExtension/Controls/Pages/SearchPages/CombinedSearchPage.cs
@@ -9,34 +9,54 @@ using Microsoft.CommandPalette.Extensions.Toolkit;
 
 namespace GitHubExtension.Controls.Pages;
 
-public sealed partial class CombinedSearchPage(ISearch search, ICacheDataManager cacheDataManager, IResources resources)
-    : SearchPage<IIssue>(search, cacheDataManager, resources)
+public sealed partial class CombinedSearchPage : SearchPage<IIssue>
 {
+    private readonly MutationCommandsFactory _mutationCommandsFactory;
+
+    public CombinedSearchPage(ISearch search, ICacheDataManager cacheDataManager, IResources resources, MutationCommandsFactory mutationCommandsFactory, MutationMediator mutationMediator)
+        : base(search, cacheDataManager, resources)
+    {
+        _mutationCommandsFactory = mutationCommandsFactory;
+        mutationMediator.MutationCompleted += OnMutationCompleted;
+    }
+
+    private void OnMutationCompleted(object? sender, EventArgs e) => RaiseItemsChanged(0);
+
     protected override ListItem GetListItem(IIssue item)
     {
         var iconType = item is IPullRequest ? "pr" : "issue";
+        List<CommandContextItem> moreCommands;
+        if (item is IPullRequest prItem)
+        {
+            moreCommands = new List<CommandContextItem>
+            {
+                new(new CopyCommand(string.Format(CultureInfo.CurrentCulture, Resources.GetResource("Commands_Copy_GitCheckoutCommand"), prItem.SourceBranch), Resources.GetResource("Commands_Copy_Checkout"), Resources)),
+                new(new CopyCommand(prItem.SourceBranch, Resources.GetResource("Commands_Copy_Source_Branch"), Resources)),
+                new(new CopyCommand(prItem.HtmlUrl, $"{Resources.GetResource("Commands_CopyURL")}", Resources)),
+                new(new CopyCommand(prItem.Title, $"{Resources.GetResource("Commands_Copy")} {Resources.GetResource("Pages_PullRequest_Title")}", Resources)),
+                new(new CopyCommand(prItem.Number.ToString(CultureInfo.InvariantCulture), $"{Resources.GetResource("Commands_CopyPullRequestNumber")}", Resources)),
+                new(new PullRequestContentPage(prItem, Resources, _mutationCommandsFactory)),
+            };
+            moreCommands.AddRange(_mutationCommandsFactory.GetPullRequestCommands(prItem));
+        }
+        else
+        {
+            moreCommands = new List<CommandContextItem>
+            {
+                new(new CopyCommand(item.HtmlUrl, $"{Resources.GetResource("Commands_CopyURL")}", Resources)),
+                new(new CopyCommand(item.Title, $"{Resources.GetResource("Commands_CopyIssueTitle")}", Resources)),
+                new(new CopyCommand(item.Number.ToString(CultureInfo.InvariantCulture), $"{Resources.GetResource("Commands_CopyIssueNumber")}", Resources)),
+                new(new IssueContentPage(item, Resources, _mutationCommandsFactory)),
+            };
+            moreCommands.AddRange(_mutationCommandsFactory.GetIssueCommands(item));
+        }
+
         return new ListItem(new LinkCommand(item, Resources))
         {
             Title = item.Title,
             Icon = GitHubIcon.IconDictionary[iconType],
             Subtitle = $"{GetOwner(item.HtmlUrl)}/{GetRepo(item.HtmlUrl)}/#{item.Number}",
-            MoreCommands = item is IPullRequest prItem
-                ? new CommandContextItem[]
-                {
-                    new(new CopyCommand(string.Format(CultureInfo.CurrentCulture, Resources.GetResource("Commands_Copy_GitCheckoutCommand"), prItem.SourceBranch), Resources.GetResource("Commands_Copy_Checkout"), Resources)),
-                    new(new CopyCommand(prItem.SourceBranch, Resources.GetResource("Commands_Copy_Source_Branch"), Resources)),
-                    new(new CopyCommand(prItem.HtmlUrl, $"{Resources.GetResource("Commands_CopyURL")}", Resources)),
-                    new(new CopyCommand(prItem.Title, $"{Resources.GetResource("Commands_Copy")} {Resources.GetResource("Pages_PullRequest_Title")}", Resources)),
-                    new(new CopyCommand(prItem.Number.ToString(CultureInfo.InvariantCulture), $"{Resources.GetResource("Commands_CopyPullRequestNumber")}", Resources)),
-                    new(new PullRequestContentPage(prItem, Resources)),
-                }
-                : new CommandContextItem[]
-                {
-                    new(new CopyCommand(item.HtmlUrl, $"{Resources.GetResource("Commands_CopyURL")}", Resources)),
-                    new(new CopyCommand(item.Title, $"{Resources.GetResource("Commands_CopyIssueTitle")}", Resources)),
-                    new(new CopyCommand(item.Number.ToString(CultureInfo.InvariantCulture), $"{Resources.GetResource("Commands_CopyIssueNumber")}", Resources)),
-                    new(new IssueContentPage(item, Resources)),
-                },
+            MoreCommands = moreCommands.ToArray(),
             Tags = GetTags(item),
         };
     }

--- a/GitHubExtension/Controls/Pages/SearchPages/IssuesSearchPage.cs
+++ b/GitHubExtension/Controls/Pages/SearchPages/IssuesSearchPage.cs
@@ -9,23 +9,36 @@ using Microsoft.CommandPalette.Extensions.Toolkit;
 
 namespace GitHubExtension.Controls.Pages;
 
-public sealed partial class IssuesSearchPage(ISearch search, ICacheDataManager cacheDataManager, IResources resources)
-    : SearchPage<IIssue>(search, cacheDataManager, resources)
+public sealed partial class IssuesSearchPage : SearchPage<IIssue>
 {
+    private readonly MutationCommandsFactory _mutationCommandsFactory;
+
+    public IssuesSearchPage(ISearch search, ICacheDataManager cacheDataManager, IResources resources, MutationCommandsFactory mutationCommandsFactory, MutationMediator mutationMediator)
+        : base(search, cacheDataManager, resources)
+    {
+        _mutationCommandsFactory = mutationCommandsFactory;
+        mutationMediator.MutationCompleted += OnMutationCompleted;
+    }
+
+    private void OnMutationCompleted(object? sender, EventArgs e) => RaiseItemsChanged(0);
+
     protected override ListItem GetListItem(IIssue item)
     {
+        var moreCommands = new List<CommandContextItem>
+        {
+            new(new CopyCommand(item.HtmlUrl, $"{Resources.GetResource("Commands_CopyURL")}", Resources)),
+            new(new CopyCommand(item.Title, $"{Resources.GetResource("Commands_CopyIssueTitle")}", Resources)),
+            new(new CopyCommand(item.Number.ToString(CultureInfo.InvariantCulture), $"{Resources.GetResource("Commands_CopyIssueNumber")}", Resources)),
+            new(new IssueContentPage(item, Resources, _mutationCommandsFactory)),
+        };
+        moreCommands.AddRange(_mutationCommandsFactory.GetIssueCommands(item));
+
         return new ListItem(new LinkCommand(item, Resources))
         {
             Title = item.Title,
             Icon = GitHubIcon.IconDictionary["issue"],
             Subtitle = $"{GetOwner(item.HtmlUrl)}/{GetRepo(item.HtmlUrl)}/#{item.Number}",
-            MoreCommands = new CommandContextItem[]
-            {
-                new(new CopyCommand(item.HtmlUrl, $"{Resources.GetResource("Commands_CopyURL")}", Resources)),
-                new(new CopyCommand(item.Title, $"{Resources.GetResource("Commands_CopyIssueTitle")}", Resources)),
-                new(new CopyCommand(item.Number.ToString(CultureInfo.InvariantCulture), $"{Resources.GetResource("Commands_CopyIssueNumber")}", Resources)),
-                new(new IssueContentPage(item, Resources)),
-            },
+            MoreCommands = moreCommands.ToArray(),
             Tags = GetTags(item),
         };
     }

--- a/GitHubExtension/Controls/Pages/SearchPages/PullRequestsSearchPage.cs
+++ b/GitHubExtension/Controls/Pages/SearchPages/PullRequestsSearchPage.cs
@@ -9,25 +9,38 @@ using Microsoft.CommandPalette.Extensions.Toolkit;
 
 namespace GitHubExtension.Controls.Pages;
 
-public sealed partial class PullRequestsSearchPage(ISearch search, ICacheDataManager cacheDataManager, IResources resources)
-    : SearchPage<IPullRequest>(search, cacheDataManager, resources)
+public sealed partial class PullRequestsSearchPage : SearchPage<IPullRequest>
 {
+    private readonly MutationCommandsFactory _mutationCommandsFactory;
+
+    public PullRequestsSearchPage(ISearch search, ICacheDataManager cacheDataManager, IResources resources, MutationCommandsFactory mutationCommandsFactory, MutationMediator mutationMediator)
+        : base(search, cacheDataManager, resources)
+    {
+        _mutationCommandsFactory = mutationCommandsFactory;
+        mutationMediator.MutationCompleted += OnMutationCompleted;
+    }
+
+    private void OnMutationCompleted(object? sender, EventArgs e) => RaiseItemsChanged(0);
+
     protected override ListItem GetListItem(IPullRequest item)
     {
+        var moreCommands = new List<CommandContextItem>
+        {
+            new(new CopyCommand(string.Format(CultureInfo.CurrentCulture, Resources.GetResource("Commands_Copy_GitCheckoutCommand"), item.SourceBranch), Resources.GetResource("Commands_Copy_Checkout"), Resources)),
+            new(new CopyCommand(item.SourceBranch, Resources.GetResource("Commands_Copy_Source_Branch"), Resources)),
+            new(new CopyCommand(item.HtmlUrl, Resources.GetResource("Commands_CopyURL"), Resources)),
+            new(new CopyCommand(item.Title, Resources.GetResource("Commands_CopyPullRequestTitle"), Resources)),
+            new(new CopyCommand(item.Number.ToString(CultureInfo.InvariantCulture), Resources.GetResource("Commands_CopyPullRequestNumber"), Resources)),
+            new(new PullRequestContentPage(item, Resources, _mutationCommandsFactory)),
+        };
+        moreCommands.AddRange(_mutationCommandsFactory.GetPullRequestCommands(item));
+
         return new ListItem(new LinkCommand(item, Resources))
         {
             Title = item.Title,
             Icon = GitHubIcon.IconDictionary["pr"],
             Subtitle = $"{GetOwner(item.HtmlUrl)}/{GetRepo(item.HtmlUrl)}/#{item.Number}",
-            MoreCommands = new CommandContextItem[]
-            {
-                new(new CopyCommand(string.Format(CultureInfo.CurrentCulture, Resources.GetResource("Commands_Copy_GitCheckoutCommand"), item.SourceBranch), Resources.GetResource("Commands_Copy_Checkout"), Resources)),
-                new(new CopyCommand(item.SourceBranch, Resources.GetResource("Commands_Copy_Source_Branch"), Resources)),
-                new(new CopyCommand(item.HtmlUrl, Resources.GetResource("Commands_CopyURL"), Resources)),
-                new(new CopyCommand(item.Title, Resources.GetResource("Commands_CopyPullRequestTitle"), Resources)),
-                new(new CopyCommand(item.Number.ToString(CultureInfo.InvariantCulture), Resources.GetResource("Commands_CopyPullRequestNumber"), Resources)),
-                new(new PullRequestContentPage(item, Resources)),
-            },
+            MoreCommands = moreCommands.ToArray(),
             Tags = GetTags(item),
         };
     }

--- a/GitHubExtension/Controls/Pages/SearchPages/SearchPageFactory.cs
+++ b/GitHubExtension/Controls/Pages/SearchPages/SearchPageFactory.cs
@@ -17,23 +17,27 @@ public class SearchPageFactory : ISearchPageFactory
     private readonly ISearchRepository _searchRepository;
     private readonly IResources _resources;
     private readonly SavedSearchesMediator _savedSearchesMediator;
+    private readonly MutationCommandsFactory _mutationCommandsFactory;
+    private readonly MutationMediator _mutationMediator;
 
-    public SearchPageFactory(ICacheDataManager cacheDataManager, ISearchRepository searchRepository, IResources resources, SavedSearchesMediator savedSearchesMediator)
+    public SearchPageFactory(ICacheDataManager cacheDataManager, ISearchRepository searchRepository, IResources resources, SavedSearchesMediator savedSearchesMediator, MutationCommandsFactory mutationCommandsFactory, MutationMediator mutationMediator)
     {
         _cacheDataManager = cacheDataManager;
         _searchRepository = searchRepository;
         _resources = resources;
         _savedSearchesMediator = savedSearchesMediator;
+        _mutationCommandsFactory = mutationCommandsFactory;
+        _mutationMediator = mutationMediator;
     }
 
     private ListPage CreatePageForSearch(ISearch search)
     {
         return search.Type switch
         {
-            SearchType.PullRequests => new PullRequestsSearchPage(search, _cacheDataManager, _resources),
-            SearchType.Issues => new IssuesSearchPage(search, _cacheDataManager, _resources),
+            SearchType.PullRequests => new PullRequestsSearchPage(search, _cacheDataManager, _resources, _mutationCommandsFactory, _mutationMediator),
+            SearchType.Issues => new IssuesSearchPage(search, _cacheDataManager, _resources, _mutationCommandsFactory, _mutationMediator),
             SearchType.Repositories => new RepositoriesSearchPage(search, _cacheDataManager, _resources),
-            _ => new CombinedSearchPage(search, _cacheDataManager, _resources),
+            _ => new CombinedSearchPage(search, _cacheDataManager, _resources, _mutationCommandsFactory, _mutationMediator),
         };
     }
 

--- a/GitHubExtension/DataManager/Data/GitHubMutationManager.cs
+++ b/GitHubExtension/DataManager/Data/GitHubMutationManager.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Client;
+using GitHubExtension.Controls;
+using Octokit;
+using Serilog;
+
+namespace GitHubExtension.DataManager.Data;
+
+public sealed class GitHubMutationManager : IGitHubMutationManager
+{
+    private static readonly Lazy<ILogger> _logger = new(() => Serilog.Log.ForContext("SourceContext", nameof(GitHubMutationManager)));
+
+    private static readonly ILogger _log = _logger.Value;
+
+    private readonly GitHubClientProvider _gitHubClientProvider;
+
+    public GitHubMutationManager(GitHubClientProvider gitHubClientProvider)
+    {
+        _gitHubClientProvider = gitHubClientProvider;
+    }
+
+    public async Task CloseIssueAsync(IIssue issue)
+    {
+        var (owner, repo, number) = Parse(issue);
+        var client = await _gitHubClientProvider.GetClientForLoggedInDeveloper(false);
+        await client.Issue.Update(owner, repo, number, new IssueUpdate { State = ItemState.Closed });
+        _log.Information($"Closed issue {owner}/{repo}#{number}.");
+    }
+
+    public async Task ReopenIssueAsync(IIssue issue)
+    {
+        var (owner, repo, number) = Parse(issue);
+        var client = await _gitHubClientProvider.GetClientForLoggedInDeveloper(false);
+        await client.Issue.Update(owner, repo, number, new IssueUpdate { State = ItemState.Open });
+        _log.Information($"Reopened issue {owner}/{repo}#{number}.");
+    }
+
+    public async Task ClosePullRequestAsync(IPullRequest pullRequest)
+    {
+        var (owner, repo, number) = Parse(pullRequest);
+        var client = await _gitHubClientProvider.GetClientForLoggedInDeveloper(false);
+        await client.PullRequest.Update(owner, repo, number, new PullRequestUpdate { State = ItemState.Closed });
+        _log.Information($"Closed pull request {owner}/{repo}#{number}.");
+    }
+
+    public async Task ReopenPullRequestAsync(IPullRequest pullRequest)
+    {
+        var (owner, repo, number) = Parse(pullRequest);
+        var client = await _gitHubClientProvider.GetClientForLoggedInDeveloper(false);
+        await client.PullRequest.Update(owner, repo, number, new PullRequestUpdate { State = ItemState.Open });
+        _log.Information($"Reopened pull request {owner}/{repo}#{number}.");
+    }
+
+    public async Task MergePullRequestAsync(IPullRequest pullRequest)
+    {
+        var (owner, repo, number) = Parse(pullRequest);
+        var client = await _gitHubClientProvider.GetClientForLoggedInDeveloper(false);
+        await client.PullRequest.Merge(owner, repo, number, new MergePullRequest());
+        _log.Information($"Merged pull request {owner}/{repo}#{number}.");
+    }
+
+    private static (string Owner, string Repo, int Number) Parse(IIssue issue)
+    {
+        var owner = Validation.ParseOwnerFromGitHubURL(issue.HtmlUrl);
+        var repo = Validation.ParseRepositoryFromGitHubURL(issue.HtmlUrl);
+        return (owner, repo, (int)issue.Number);
+    }
+}

--- a/GitHubExtension/DataManager/IGitHubMutationManager.cs
+++ b/GitHubExtension/DataManager/IGitHubMutationManager.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Controls;
+
+namespace GitHubExtension.DataManager;
+
+// Performs write operations against existing issues and pull requests. Kept
+// separate from the read-only cache/data-requester path. Shared by M3 (state
+// changes) and reused by later create/workflow milestones.
+public interface IGitHubMutationManager
+{
+    Task CloseIssueAsync(IIssue issue);
+
+    Task ReopenIssueAsync(IIssue issue);
+
+    Task ClosePullRequestAsync(IPullRequest pullRequest);
+
+    Task ReopenPullRequestAsync(IPullRequest pullRequest);
+
+    Task MergePullRequestAsync(IPullRequest pullRequest);
+}

--- a/GitHubExtension/DataManager/PullRequestSourceBranchDecorator.cs
+++ b/GitHubExtension/DataManager/PullRequestSourceBranchDecorator.cs
@@ -42,6 +42,8 @@ public sealed class PullRequestSourceBranchDecorator : IPullRequest
 
     public string Body => _source.Body;
 
+    public string State => _source.State;
+
     public string HtmlUrl => _source.HtmlUrl;
 
     public IEnumerable<ILabel> Labels => _source.Labels;

--- a/GitHubExtension/Program.cs
+++ b/GitHubExtension/Program.cs
@@ -132,11 +132,15 @@ public class Program
 
         var savedSearchesMediator = new SavedSearchesMediator();
         var notificationsMediator = new NotificationsMediator();
+        var mutationMediator = new MutationMediator();
 
         var notificationsDataManager = new NotificationsDataManager(gitHubClientProvider);
         var notificationsPage = new NotificationsPage(notificationsDataManager, notificationsMediator, resources);
 
-        var searchPageFactory = new SearchPageFactory(cacheDataManager, searchRepository, resources, savedSearchesMediator);
+        var mutationManager = new GitHubMutationManager(gitHubClientProvider);
+        var mutationCommandsFactory = new MutationCommandsFactory(mutationManager, mutationMediator, resources);
+
+        var searchPageFactory = new SearchPageFactory(cacheDataManager, searchRepository, resources, savedSearchesMediator, mutationCommandsFactory, mutationMediator);
 
         var addSearchForm = new SaveSearchForm(searchRepository, resources, savedSearchesMediator);
         var addSearchListItem = new AddSearchListItem(new SaveSearchPage(addSearchForm, new StatusMessage(), resources), resources);

--- a/GitHubExtension/Strings/en-US/Resources.resw
+++ b/GitHubExtension/Strings/en-US/Resources.resw
@@ -361,6 +361,90 @@
     <value>Failed to mark notification as read</value>
     <comment>Toast shown when marking a notification as read fails</comment>
   </data>
+  <data name="Commands_CloseIssue" xml:space="preserve">
+    <value>Close issue</value>
+    <comment>Command name for closing an issue</comment>
+  </data>
+  <data name="Commands_ReopenIssue" xml:space="preserve">
+    <value>Reopen issue</value>
+    <comment>Command name for reopening an issue</comment>
+  </data>
+  <data name="Commands_ClosePullRequest" xml:space="preserve">
+    <value>Close pull request</value>
+    <comment>Command name for closing a pull request</comment>
+  </data>
+  <data name="Commands_ReopenPullRequest" xml:space="preserve">
+    <value>Reopen pull request</value>
+    <comment>Command name for reopening a pull request</comment>
+  </data>
+  <data name="Commands_MergePullRequest" xml:space="preserve">
+    <value>Merge pull request</value>
+    <comment>Command name for merging a pull request</comment>
+  </data>
+  <data name="Message_CloseIssue_Success" xml:space="preserve">
+    <value>Issue closed</value>
+    <comment>Toast shown after an issue is closed</comment>
+  </data>
+  <data name="Message_CloseIssue_Error" xml:space="preserve">
+    <value>Failed to close issue</value>
+    <comment>Toast shown when closing an issue fails</comment>
+  </data>
+  <data name="Message_ReopenIssue_Success" xml:space="preserve">
+    <value>Issue reopened</value>
+    <comment>Toast shown after an issue is reopened</comment>
+  </data>
+  <data name="Message_ReopenIssue_Error" xml:space="preserve">
+    <value>Failed to reopen issue</value>
+    <comment>Toast shown when reopening an issue fails</comment>
+  </data>
+  <data name="Message_ClosePullRequest_Success" xml:space="preserve">
+    <value>Pull request closed</value>
+    <comment>Toast shown after a pull request is closed</comment>
+  </data>
+  <data name="Message_ClosePullRequest_Error" xml:space="preserve">
+    <value>Failed to close pull request</value>
+    <comment>Toast shown when closing a pull request fails</comment>
+  </data>
+  <data name="Message_ReopenPullRequest_Success" xml:space="preserve">
+    <value>Pull request reopened</value>
+    <comment>Toast shown after a pull request is reopened</comment>
+  </data>
+  <data name="Message_ReopenPullRequest_Error" xml:space="preserve">
+    <value>Failed to reopen pull request</value>
+    <comment>Toast shown when reopening a pull request fails</comment>
+  </data>
+  <data name="Message_MergePullRequest_Success" xml:space="preserve">
+    <value>Pull request merged</value>
+    <comment>Toast shown after a pull request is merged</comment>
+  </data>
+  <data name="Message_MergePullRequest_Error" xml:space="preserve">
+    <value>Failed to merge pull request</value>
+    <comment>Toast shown when merging a pull request fails</comment>
+  </data>
+  <data name="Confirm_CloseIssue_Title" xml:space="preserve">
+    <value>Close this issue?</value>
+    <comment>Confirmation title before closing an issue</comment>
+  </data>
+  <data name="Confirm_CloseIssue_Description" xml:space="preserve">
+    <value>This will close the issue on GitHub.</value>
+    <comment>Confirmation description before closing an issue</comment>
+  </data>
+  <data name="Confirm_ClosePullRequest_Title" xml:space="preserve">
+    <value>Close this pull request?</value>
+    <comment>Confirmation title before closing a pull request</comment>
+  </data>
+  <data name="Confirm_ClosePullRequest_Description" xml:space="preserve">
+    <value>This will close the pull request on GitHub without merging.</value>
+    <comment>Confirmation description before closing a pull request</comment>
+  </data>
+  <data name="Confirm_MergePullRequest_Title" xml:space="preserve">
+    <value>Merge this pull request?</value>
+    <comment>Confirmation title before merging a pull request</comment>
+  </data>
+  <data name="Confirm_MergePullRequest_Description" xml:space="preserve">
+    <value>This will merge the pull request into its base branch.</value>
+    <comment>Confirmation description before merging a pull request</comment>
+  </data>
   <data name="ExtensionTitle" xml:space="preserve">
     <value>GitHub Extension (Preview)</value>
     <comment>Title for the extension</comment>


### PR DESCRIPTION
Part of the CmdPal GitHub extension parity roadmap (stacked on M2, PR #289).

## Summary
Introduces shared write/mutation infrastructure and the first state-changing actions on existing issues and pull requests.

### Mutation infrastructure (reused by M4/M5)
- IGitHubMutationManager / GitHubMutationManager: Octokit REST writes (close/reopen issue, close/reopen/merge PR).
- MutationMediator: weak-event signal so open surfaces refresh after a write (pages are recreated on every top-level rebuild, so strong subscriptions would leak).
- GitHubMutationCommand: runs a single write, shows a success/error toast, notifies the mediator.
- ConfirmedCommand: wraps destructive actions in CommandResult.Confirm.
- MutationCommandsFactory: state-aware command building (close if open / reopen if closed; merge + close for open PRs).

### Wiring
- List views: IssuesSearchPage, PullRequestsSearchPage, CombinedSearchPage append mutation commands and subscribe to the mediator via a method-group handler to refresh on completion.
- Detail views: IssueContentPage / PullRequestContentPage append the same mutation commands.
- Composition root (Program.cs) constructs the manager/mediator/factory and threads them through SearchPageFactory.

### Safety
Destructive ops (merge, close) are marked \IsCritical\ and require an explicit confirmation step; reopen runs immediately.

## Deferrals (documented in plan)
- **Add Comment** -> M4 (needs FormContent, natural fit for the create/forms milestone).
- **Enable/Disable Auto-merge** -> M6 (GraphQL-only mutation; GraphQL client arrives in M6).

## Tests
- New \MutationCommandsFactoryTests\ covering state-aware command building and confirmation deferral.
- Full suite: 177/177 passing. Build clean (x64 Debug).

## Localization
Added command names, success/error toasts, and confirmation title/description strings to \Resources.resw\.