### PR TITLE
M4: Create flows (issue/PR/branch) + Add Comment

### DIFF
--- a/GitHubExtension.Test/Controls/CreateFormsTests.cs
+++ b/GitHubExtension.Test/Controls/CreateFormsTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using GitHubExtension.Controls;
+using GitHubExtension.Controls.Forms;
+using GitHubExtension.DataManager;
+using GitHubExtension.Helpers;
+using Moq;
+
+namespace GitHubExtension.Test.Controls;
+
+[TestClass]
+public class CreateFormsTests
+{
+    private static Mock<IResources> CreateResources()
+    {
+        var resources = new Mock<IResources>();
+        resources.Setup(x => x.GetResource(It.IsAny<string>(), null)).Returns<string, object>((key, _) => key);
+        return resources;
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void CreateIssueForm_TemplateJson_IsValidJson()
+    {
+        var createManager = new Mock<IGitHubCreateManager>();
+        var form = new CreateIssueForm(createManager.Object, CreateResources().Object, "owner/repo");
+
+        var json = form.TemplateJson;
+
+        var parsed = JsonDocument.Parse(json);
+        Assert.AreEqual("AdaptiveCard", parsed.RootElement.GetProperty("type").GetString());
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void CreatePullRequestForm_TemplateJson_IsValidJson()
+    {
+        var createManager = new Mock<IGitHubCreateManager>();
+        var form = new CreatePullRequestForm(createManager.Object, CreateResources().Object);
+
+        var json = form.TemplateJson;
+
+        var parsed = JsonDocument.Parse(json);
+        Assert.AreEqual("AdaptiveCard", parsed.RootElement.GetProperty("type").GetString());
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void CreateBranchForm_TemplateJson_IsValidJson()
+    {
+        var createManager = new Mock<IGitHubCreateManager>();
+        var form = new CreateBranchForm(createManager.Object, CreateResources().Object);
+
+        var json = form.TemplateJson;
+
+        var parsed = JsonDocument.Parse(json);
+        Assert.AreEqual("AdaptiveCard", parsed.RootElement.GetProperty("type").GetString());
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void AddCommentForm_TemplateJson_IsValidJson()
+    {
+        var createManager = new Mock<IGitHubCreateManager>();
+        var issue = new Mock<IIssue>();
+        issue.Setup(x => x.Title).Returns("An issue title");
+        var form = new AddCommentForm(issue.Object, createManager.Object, CreateResources().Object);
+
+        var json = form.TemplateJson;
+
+        var parsed = JsonDocument.Parse(json);
+        Assert.AreEqual("AdaptiveCard", parsed.RootElement.GetProperty("type").GetString());
+    }
+}

--- a/GitHubExtension.Test/Controls/GitHubCreateManagerTests.cs
+++ b/GitHubExtension.Test/Controls/GitHubCreateManagerTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.DataManager.Data;
+
+namespace GitHubExtension.Test.Controls;
+
+[TestClass]
+public class GitHubCreateManagerTests
+{
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void ParseOwnerRepo_ShortForm_ParsesOwnerAndRepo()
+    {
+        var (owner, repo) = GitHubCreateManager.ParseOwnerRepo("octocat/hello-world");
+
+        Assert.AreEqual("octocat", owner);
+        Assert.AreEqual("hello-world", repo);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void ParseOwnerRepo_WithSurroundingWhitespace_Trims()
+    {
+        var (owner, repo) = GitHubCreateManager.ParseOwnerRepo("  octocat / hello-world  ");
+
+        Assert.AreEqual("octocat", owner);
+        Assert.AreEqual("hello-world", repo);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void ParseOwnerRepo_FullUrl_ParsesOwnerAndRepo()
+    {
+        var (owner, repo) = GitHubCreateManager.ParseOwnerRepo("https://github.com/octocat/hello-world");
+
+        Assert.AreEqual("octocat", owner);
+        Assert.AreEqual("hello-world", repo);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    [ExpectedException(typeof(ArgumentException))]
+    public void ParseOwnerRepo_Empty_Throws()
+    {
+        GitHubCreateManager.ParseOwnerRepo("   ");
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    [ExpectedException(typeof(ArgumentException))]
+    public void ParseOwnerRepo_MissingRepo_Throws()
+    {
+        GitHubCreateManager.ParseOwnerRepo("octocat");
+    }
+}

--- a/GitHubExtension.Test/Controls/MutationCommandsFactoryTests.cs
+++ b/GitHubExtension.Test/Controls/MutationCommandsFactoryTests.cs
@@ -16,10 +16,11 @@ public class MutationCommandsFactoryTests
     private static (MutationCommandsFactory Factory, Mock<IGitHubMutationManager> Manager, MutationMediator Mediator) CreateFactory()
     {
         var manager = new Mock<IGitHubMutationManager>();
+        var createManager = new Mock<IGitHubCreateManager>();
         var mediator = new MutationMediator();
         var resources = new Mock<IResources>();
         resources.Setup(x => x.GetResource(It.IsAny<string>(), null)).Returns<string, object>((key, _) => key);
-        var factory = new MutationCommandsFactory(manager.Object, mediator, resources.Object);
+        var factory = new MutationCommandsFactory(manager.Object, createManager.Object, mediator, resources.Object);
         return (factory, manager, mediator);
     }
 
@@ -51,7 +52,7 @@ public class MutationCommandsFactoryTests
         var (factory, _, _) = CreateFactory();
         var commands = factory.GetIssueCommands(CreateIssue("Open").Object).ToList();
 
-        Assert.AreEqual(1, commands.Count);
+        Assert.AreEqual(2, commands.Count);
         Assert.AreEqual("Commands_CloseIssue", commands[0].Command!.Name);
         Assert.IsTrue(commands[0].IsCritical);
     }
@@ -63,7 +64,7 @@ public class MutationCommandsFactoryTests
         var (factory, _, _) = CreateFactory();
         var commands = factory.GetIssueCommands(CreateIssue("Closed").Object).ToList();
 
-        Assert.AreEqual(1, commands.Count);
+        Assert.AreEqual(2, commands.Count);
         Assert.AreEqual("Commands_ReopenIssue", commands[0].Command!.Name);
         Assert.IsFalse(commands[0].IsCritical);
     }
@@ -75,7 +76,7 @@ public class MutationCommandsFactoryTests
         var (factory, _, _) = CreateFactory();
         var commands = factory.GetPullRequestCommands(CreatePullRequest("Open").Object).ToList();
 
-        Assert.AreEqual(2, commands.Count);
+        Assert.AreEqual(3, commands.Count);
         Assert.AreEqual("Commands_MergePullRequest", commands[0].Command!.Name);
         Assert.AreEqual("Commands_ClosePullRequest", commands[1].Command!.Name);
         Assert.IsTrue(commands[0].IsCritical);
@@ -89,7 +90,7 @@ public class MutationCommandsFactoryTests
         var (factory, _, _) = CreateFactory();
         var commands = factory.GetPullRequestCommands(CreatePullRequest("Closed").Object).ToList();
 
-        Assert.AreEqual(1, commands.Count);
+        Assert.AreEqual(2, commands.Count);
         Assert.AreEqual("Commands_ReopenPullRequest", commands[0].Command!.Name);
         Assert.IsFalse(commands[0].IsCritical);
     }

--- a/GitHubExtension.Test/Controls/SearchPagesTests.cs
+++ b/GitHubExtension.Test/Controls/SearchPagesTests.cs
@@ -20,8 +20,9 @@ public class SearchPagesTests
     private static (MutationCommandsFactory Factory, MutationMediator Mediator) CreateMutationDeps(Mock<IResources> resources)
     {
         var mutationManager = new Mock<IGitHubMutationManager>();
+        var createManager = new Mock<IGitHubCreateManager>();
         var mediator = new MutationMediator();
-        var factory = new MutationCommandsFactory(mutationManager.Object, mediator, resources.Object);
+        var factory = new MutationCommandsFactory(mutationManager.Object, createManager.Object, mediator, resources.Object);
         return (factory, mediator);
     }
 

--- a/GitHubExtension.Test/Controls/TopLevelSearchesTest.cs
+++ b/GitHubExtension.Test/Controls/TopLevelSearchesTest.cs
@@ -113,8 +113,9 @@ public class TopLevelSearchesTest
             var mockDeveloperIdProvider = TestHelpers.CreateMockDeveloperIdProvider();
             var mockCacheDataManager = new Mock<ICacheDataManager>().Object;
             var mutationManager = new Mock<IGitHubMutationManager>().Object;
+            var createManager = new Mock<IGitHubCreateManager>().Object;
             var mutationMediator = new MutationMediator();
-            var mutationCommandsFactory = new MutationCommandsFactory(mutationManager, mutationMediator, resources);
+            var mutationCommandsFactory = new MutationCommandsFactory(mutationManager, createManager, mutationMediator, resources);
             var searchPageFactory = new SearchPageFactory(mockCacheDataManager, persistentDataManager, resources, mediator, mutationCommandsFactory, mutationMediator);
 
             var addSearchForm = new SaveSearchForm(persistentDataManager, resources, mediator);

--- a/GitHubExtension.Test/Helpers/TestSetupHelpers.cs
+++ b/GitHubExtension.Test/Helpers/TestSetupHelpers.cs
@@ -175,6 +175,7 @@ public partial class TestHelpers
         var mockNotificationsDataManager = new Mock<INotificationsDataManager>();
         mockNotificationsDataManager.Setup(x => x.GetUnreadCountAsync()).ReturnsAsync(0);
         var notificationsPage = new NotificationsPage(mockNotificationsDataManager.Object, notificationsMediator, mockResources);
-        return new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, notificationsPage, mockDeveloperIdProvider, persistentDataManager, mockResources, searchPageFactory, savedSearchesMediator, mockAuthenticationMediator, notificationsMediator);
+        var mockCreateManager = new Mock<IGitHubCreateManager>().Object;
+        return new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, notificationsPage, mockDeveloperIdProvider, persistentDataManager, mockResources, searchPageFactory, savedSearchesMediator, mockAuthenticationMediator, notificationsMediator, mockCreateManager);
     }
 }

--- a/GitHubExtension/Controls/Commands/MutationCommandsFactory.cs
+++ b/GitHubExtension/Controls/Commands/MutationCommandsFactory.cs
@@ -2,6 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using GitHubExtension.Controls.Forms;
+using GitHubExtension.Controls.Pages;
 using GitHubExtension.DataManager;
 using GitHubExtension.Helpers;
 using Microsoft.CommandPalette.Extensions.Toolkit;
@@ -13,6 +15,7 @@ namespace GitHubExtension.Controls.Commands;
 public sealed class MutationCommandsFactory
 {
     private readonly IGitHubMutationManager _mutationManager;
+    private readonly IGitHubCreateManager _createManager;
     private readonly MutationMediator _mediator;
     private readonly IResources _resources;
 
@@ -20,14 +23,28 @@ public sealed class MutationCommandsFactory
     private static readonly IconInfo ReopenIcon = new("\uE72C");
     private static readonly IconInfo MergeIcon = new("\uE8FB");
 
-    public MutationCommandsFactory(IGitHubMutationManager mutationManager, MutationMediator mediator, IResources resources)
+    public MutationCommandsFactory(IGitHubMutationManager mutationManager, IGitHubCreateManager createManager, MutationMediator mediator, IResources resources)
     {
         _mutationManager = mutationManager;
+        _createManager = createManager;
         _mediator = mediator;
         _resources = resources;
     }
 
     private static bool IsOpen(IIssue issue) => string.Equals(issue.State, "Open", StringComparison.OrdinalIgnoreCase);
+
+    private CommandContextItem BuildAddCommentCommand(IIssue issue)
+    {
+        var page = new GitHubFormPage(
+            new AddCommentForm(issue, _createManager, _resources),
+            _resources,
+            "Forms_AddComment_Title",
+            "\uE90A",
+            "Message_AddComment_Success",
+            "Message_AddComment_Error");
+
+        return new CommandContextItem(page);
+    }
 
     public IEnumerable<CommandContextItem> GetIssueCommands(IIssue issue)
     {
@@ -64,6 +81,8 @@ public sealed class MutationCommandsFactory
 
             items.Add(new CommandContextItem(reopen));
         }
+
+        items.Add(BuildAddCommentCommand(issue));
 
         return items;
     }
@@ -120,6 +139,8 @@ public sealed class MutationCommandsFactory
 
             items.Add(new CommandContextItem(reopen));
         }
+
+        items.Add(BuildAddCommentCommand(pullRequest));
 
         return items;
     }

--- a/GitHubExtension/Controls/Forms/AddCommentForm.cs
+++ b/GitHubExtension/Controls/Forms/AddCommentForm.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using GitHubExtension.DataManager;
+using GitHubExtension.Helpers;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace GitHubExtension.Controls.Forms;
+
+public sealed partial class AddCommentForm : FormContent, IGitHubForm
+{
+    private readonly IGitHubCreateManager _createManager;
+    private readonly IResources _resources;
+    private readonly IIssue _issue;
+
+    public event EventHandler<bool>? LoadingStateChanged;
+
+    public event EventHandler<FormSubmitEventArgs>? FormSubmitted;
+
+    public AddCommentForm(IIssue issue, IGitHubCreateManager createManager, IResources resources)
+    {
+        _issue = issue;
+        _createManager = createManager;
+        _resources = resources;
+    }
+
+    public Dictionary<string, string> TemplateSubstitutions => new()
+    {
+        { "{{AddCommentFormTitle}}", JsonSerializer.Serialize(_resources.GetResource("Forms_AddComment_Title")) },
+        { "{{AddCommentSubtitle}}", JsonSerializer.Serialize(_issue.Title) },
+        { "{{BodyLabel}}", JsonSerializer.Serialize(_resources.GetResource("Forms_AddComment_BodyLabel")) },
+        { "{{BodyPlaceholder}}", JsonSerializer.Serialize(_resources.GetResource("Forms_AddComment_BodyPlaceholder")) },
+        { "{{BodyErrorMessage}}", JsonSerializer.Serialize(_resources.GetResource("Forms_AddComment_BodyError")) },
+        { "{{AddCommentActionTitle}}", JsonSerializer.Serialize(_resources.GetResource("Forms_AddComment_Action")) },
+    };
+
+    public override string TemplateJson => TemplateHelper.LoadTemplateJsonFromTemplateName("AddComment", TemplateSubstitutions);
+
+    public override ICommandResult SubmitForm(string? inputs, string data)
+    {
+        LoadingStateChanged?.Invoke(this, true);
+        _ = SubmitInternalAsync(inputs);
+        return CommandResult.KeepOpen();
+    }
+
+    private async Task SubmitInternalAsync(string? inputs)
+    {
+        try
+        {
+            var payload = JsonNode.Parse(inputs ?? string.Empty) ?? throw new InvalidOperationException("No input provided.");
+            var body = payload["Body"]?.ToString() ?? string.Empty;
+
+            await _createManager.AddCommentAsync(_issue, body);
+
+            LoadingStateChanged?.Invoke(this, false);
+            FormSubmitted?.Invoke(this, new FormSubmitEventArgs(true, null));
+        }
+        catch (Exception ex)
+        {
+            LoadingStateChanged?.Invoke(this, false);
+            FormSubmitted?.Invoke(this, new FormSubmitEventArgs(false, ex));
+        }
+    }
+}

--- a/GitHubExtension/Controls/Forms/CreateBranchForm.cs
+++ b/GitHubExtension/Controls/Forms/CreateBranchForm.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using GitHubExtension.DataManager;
+using GitHubExtension.Helpers;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace GitHubExtension.Controls.Forms;
+
+public sealed partial class CreateBranchForm : FormContent, IGitHubForm
+{
+    private readonly IGitHubCreateManager _createManager;
+    private readonly IResources _resources;
+    private readonly string _initialRepository;
+
+    public event EventHandler<bool>? LoadingStateChanged;
+
+    public event EventHandler<FormSubmitEventArgs>? FormSubmitted;
+
+    public CreateBranchForm(IGitHubCreateManager createManager, IResources resources, string initialRepository = "")
+    {
+        _createManager = createManager;
+        _resources = resources;
+        _initialRepository = initialRepository;
+    }
+
+    public Dictionary<string, string> TemplateSubstitutions => new()
+    {
+        { "{{CreateBranchFormTitle}}", JsonSerializer.Serialize(_resources.GetResource("Forms_CreateBranch_Title")) },
+        { "{{RepositoryLabel}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Create_RepositoryLabel")) },
+        { "{{RepositoryPlaceholder}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Create_RepositoryPlaceholder")) },
+        { "{{RepositoryErrorMessage}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Create_RepositoryError")) },
+        { "{{RepositoryValue}}", JsonSerializer.Serialize(_initialRepository) },
+        { "{{NewBranchLabel}}", JsonSerializer.Serialize(_resources.GetResource("Forms_CreateBranch_NewBranchLabel")) },
+        { "{{NewBranchPlaceholder}}", JsonSerializer.Serialize(_resources.GetResource("Forms_CreateBranch_NewBranchPlaceholder")) },
+        { "{{NewBranchErrorMessage}}", JsonSerializer.Serialize(_resources.GetResource("Forms_CreateBranch_NewBranchError")) },
+        { "{{SourceBranchLabel}}", JsonSerializer.Serialize(_resources.GetResource("Forms_CreateBranch_SourceBranchLabel")) },
+        { "{{SourceBranchPlaceholder}}", JsonSerializer.Serialize(_resources.GetResource("Forms_CreateBranch_SourceBranchPlaceholder")) },
+        { "{{SourceBranchErrorMessage}}", JsonSerializer.Serialize(_resources.GetResource("Forms_CreateBranch_SourceBranchError")) },
+        { "{{SourceBranchValue}}", JsonSerializer.Serialize("main") },
+        { "{{CreateBranchActionTitle}}", JsonSerializer.Serialize(_resources.GetResource("Forms_CreateBranch_Action")) },
+    };
+
+    public override string TemplateJson => TemplateHelper.LoadTemplateJsonFromTemplateName("CreateBranch", TemplateSubstitutions);
+
+    public override ICommandResult SubmitForm(string? inputs, string data)
+    {
+        LoadingStateChanged?.Invoke(this, true);
+        _ = SubmitInternalAsync(inputs);
+        return CommandResult.KeepOpen();
+    }
+
+    private async Task SubmitInternalAsync(string? inputs)
+    {
+        try
+        {
+            var payload = JsonNode.Parse(inputs ?? string.Empty) ?? throw new InvalidOperationException("No input provided.");
+            var repository = payload["Repository"]?.ToString() ?? string.Empty;
+            var newBranch = payload["NewBranch"]?.ToString() ?? string.Empty;
+            var sourceBranch = payload["SourceBranch"]?.ToString() ?? string.Empty;
+
+            await _createManager.CreateBranchAsync(repository, newBranch, sourceBranch);
+
+            LoadingStateChanged?.Invoke(this, false);
+            FormSubmitted?.Invoke(this, new FormSubmitEventArgs(true, null));
+        }
+        catch (Exception ex)
+        {
+            LoadingStateChanged?.Invoke(this, false);
+            FormSubmitted?.Invoke(this, new FormSubmitEventArgs(false, ex));
+        }
+    }
+}

--- a/GitHubExtension/Controls/Forms/CreateIssueForm.cs
+++ b/GitHubExtension/Controls/Forms/CreateIssueForm.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using GitHubExtension.DataManager;
+using GitHubExtension.Helpers;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace GitHubExtension.Controls.Forms;
+
+public sealed partial class CreateIssueForm : FormContent, IGitHubForm
+{
+    private readonly IGitHubCreateManager _createManager;
+    private readonly IResources _resources;
+    private readonly string _initialRepository;
+
+    public event EventHandler<bool>? LoadingStateChanged;
+
+    public event EventHandler<FormSubmitEventArgs>? FormSubmitted;
+
+    public CreateIssueForm(IGitHubCreateManager createManager, IResources resources, string initialRepository = "")
+    {
+        _createManager = createManager;
+        _resources = resources;
+        _initialRepository = initialRepository;
+    }
+
+    public Dictionary<string, string> TemplateSubstitutions => new()
+    {
+        { "{{CreateIssueFormTitle}}", JsonSerializer.Serialize(_resources.GetResource("Forms_CreateIssue_Title")) },
+        { "{{RepositoryLabel}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Create_RepositoryLabel")) },
+        { "{{RepositoryPlaceholder}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Create_RepositoryPlaceholder")) },
+        { "{{RepositoryErrorMessage}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Create_RepositoryError")) },
+        { "{{RepositoryValue}}", JsonSerializer.Serialize(_initialRepository) },
+        { "{{TitleLabel}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Create_TitleLabel")) },
+        { "{{TitlePlaceholder}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Create_TitlePlaceholder")) },
+        { "{{TitleErrorMessage}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Create_TitleError")) },
+        { "{{BodyLabel}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Create_BodyLabel")) },
+        { "{{BodyPlaceholder}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Create_BodyPlaceholder")) },
+        { "{{CreateIssueActionTitle}}", JsonSerializer.Serialize(_resources.GetResource("Forms_CreateIssue_Action")) },
+    };
+
+    public override string TemplateJson => TemplateHelper.LoadTemplateJsonFromTemplateName("CreateIssue", TemplateSubstitutions);
+
+    public override ICommandResult SubmitForm(string? inputs, string data)
+    {
+        LoadingStateChanged?.Invoke(this, true);
+        _ = SubmitInternalAsync(inputs);
+        return CommandResult.KeepOpen();
+    }
+
+    private async Task SubmitInternalAsync(string? inputs)
+    {
+        try
+        {
+            var payload = JsonNode.Parse(inputs ?? string.Empty) ?? throw new InvalidOperationException("No input provided.");
+            var repository = payload["Repository"]?.ToString() ?? string.Empty;
+            var title = payload["Title"]?.ToString() ?? string.Empty;
+            var body = payload["Body"]?.ToString() ?? string.Empty;
+
+            await _createManager.CreateIssueAsync(repository, title, body);
+
+            LoadingStateChanged?.Invoke(this, false);
+            FormSubmitted?.Invoke(this, new FormSubmitEventArgs(true, null));
+        }
+        catch (Exception ex)
+        {
+            LoadingStateChanged?.Invoke(this, false);
+            FormSubmitted?.Invoke(this, new FormSubmitEventArgs(false, ex));
+        }
+    }
+}

--- a/GitHubExtension/Controls/Forms/CreatePullRequestForm.cs
+++ b/GitHubExtension/Controls/Forms/CreatePullRequestForm.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using GitHubExtension.DataManager;
+using GitHubExtension.Helpers;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace GitHubExtension.Controls.Forms;
+
+public sealed partial class CreatePullRequestForm : FormContent, IGitHubForm
+{
+    private readonly IGitHubCreateManager _createManager;
+    private readonly IResources _resources;
+    private readonly string _initialRepository;
+
+    public event EventHandler<bool>? LoadingStateChanged;
+
+    public event EventHandler<FormSubmitEventArgs>? FormSubmitted;
+
+    public CreatePullRequestForm(IGitHubCreateManager createManager, IResources resources, string initialRepository = "")
+    {
+        _createManager = createManager;
+        _resources = resources;
+        _initialRepository = initialRepository;
+    }
+
+    public Dictionary<string, string> TemplateSubstitutions => new()
+    {
+        { "{{CreatePullRequestFormTitle}}", JsonSerializer.Serialize(_resources.GetResource("Forms_CreatePullRequest_Title")) },
+        { "{{RepositoryLabel}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Create_RepositoryLabel")) },
+        { "{{RepositoryPlaceholder}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Create_RepositoryPlaceholder")) },
+        { "{{RepositoryErrorMessage}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Create_RepositoryError")) },
+        { "{{RepositoryValue}}", JsonSerializer.Serialize(_initialRepository) },
+        { "{{TitleLabel}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Create_TitleLabel")) },
+        { "{{TitlePlaceholder}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Create_TitlePlaceholder")) },
+        { "{{TitleErrorMessage}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Create_TitleError")) },
+        { "{{HeadBranchLabel}}", JsonSerializer.Serialize(_resources.GetResource("Forms_CreatePullRequest_HeadLabel")) },
+        { "{{HeadBranchPlaceholder}}", JsonSerializer.Serialize(_resources.GetResource("Forms_CreatePullRequest_HeadPlaceholder")) },
+        { "{{HeadBranchErrorMessage}}", JsonSerializer.Serialize(_resources.GetResource("Forms_CreatePullRequest_HeadError")) },
+        { "{{BaseBranchLabel}}", JsonSerializer.Serialize(_resources.GetResource("Forms_CreatePullRequest_BaseLabel")) },
+        { "{{BaseBranchPlaceholder}}", JsonSerializer.Serialize(_resources.GetResource("Forms_CreatePullRequest_BasePlaceholder")) },
+        { "{{BaseBranchErrorMessage}}", JsonSerializer.Serialize(_resources.GetResource("Forms_CreatePullRequest_BaseError")) },
+        { "{{BaseBranchValue}}", JsonSerializer.Serialize("main") },
+        { "{{BodyLabel}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Create_BodyLabel")) },
+        { "{{BodyPlaceholder}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Create_BodyPlaceholder")) },
+        { "{{CreatePullRequestActionTitle}}", JsonSerializer.Serialize(_resources.GetResource("Forms_CreatePullRequest_Action")) },
+    };
+
+    public override string TemplateJson => TemplateHelper.LoadTemplateJsonFromTemplateName("CreatePullRequest", TemplateSubstitutions);
+
+    public override ICommandResult SubmitForm(string? inputs, string data)
+    {
+        LoadingStateChanged?.Invoke(this, true);
+        _ = SubmitInternalAsync(inputs);
+        return CommandResult.KeepOpen();
+    }
+
+    private async Task SubmitInternalAsync(string? inputs)
+    {
+        try
+        {
+            var payload = JsonNode.Parse(inputs ?? string.Empty) ?? throw new InvalidOperationException("No input provided.");
+            var repository = payload["Repository"]?.ToString() ?? string.Empty;
+            var title = payload["Title"]?.ToString() ?? string.Empty;
+            var headBranch = payload["HeadBranch"]?.ToString() ?? string.Empty;
+            var baseBranch = payload["BaseBranch"]?.ToString() ?? string.Empty;
+            var body = payload["Body"]?.ToString() ?? string.Empty;
+
+            await _createManager.CreatePullRequestAsync(repository, title, headBranch, baseBranch, body);
+
+            LoadingStateChanged?.Invoke(this, false);
+            FormSubmitted?.Invoke(this, new FormSubmitEventArgs(true, null));
+        }
+        catch (Exception ex)
+        {
+            LoadingStateChanged?.Invoke(this, false);
+            FormSubmitted?.Invoke(this, new FormSubmitEventArgs(false, ex));
+        }
+    }
+}

--- a/GitHubExtension/Controls/Pages/GitHubFormPage.cs
+++ b/GitHubExtension/Controls/Pages/GitHubFormPage.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Controls.Forms;
+using GitHubExtension.Helpers;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace GitHubExtension.Controls.Pages;
+
+// Reusable ContentPage host for the create/comment forms. Wires the form's
+// submit/loading events to a StatusMessage and shows a success or error toast.
+public sealed partial class GitHubFormPage : ContentPage
+{
+    private readonly FormContent _form;
+    private readonly StatusMessage _statusMessage;
+
+    public GitHubFormPage(FormContent form, IResources resources, string titleKey, string iconGlyph, string successKey, string errorKey)
+    {
+        _form = form;
+        _statusMessage = new StatusMessage();
+
+        Icon = new IconInfo(iconGlyph);
+        Title = resources.GetResource(titleKey);
+        Name = Title;
+
+        FormEventHelper.WireFormEvents(
+            (IGitHubForm)form,
+            this,
+            _statusMessage,
+            resources.GetResource(successKey),
+            resources.GetResource(errorKey));
+
+        ExtensionHost.HideStatus(_statusMessage);
+    }
+
+    public override IContent[] GetContent()
+    {
+        ExtensionHost.HideStatus(_statusMessage);
+        return [_form];
+    }
+}

--- a/GitHubExtension/Controls/Templates/AddCommentTemplate.json
+++ b/GitHubExtension/Controls/Templates/AddCommentTemplate.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "TextBlock",
+      "size": "Medium",
+      "weight": "Bolder",
+      "text": {{AddCommentFormTitle}},
+      "horizontalAlignment": "Center",
+      "wrap": true,
+      "style": "heading"
+    },
+    {
+      "type": "TextBlock",
+      "text": {{AddCommentSubtitle}},
+      "wrap": true,
+      "isSubtle": true
+    },
+    {
+      "type": "Input.Text",
+      "id": "Body",
+      "label": {{BodyLabel}},
+      "placeholder": {{BodyPlaceholder}},
+      "isMultiline": true,
+      "isRequired": true,
+      "errorMessage": {{BodyErrorMessage}}
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.Submit",
+      "title": {{AddCommentActionTitle}},
+      "data": {
+        "id": "AddCommentAction"
+      }
+    }
+  ]
+}

--- a/GitHubExtension/Controls/Templates/CreateBranchTemplate.json
+++ b/GitHubExtension/Controls/Templates/CreateBranchTemplate.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "TextBlock",
+      "size": "Medium",
+      "weight": "Bolder",
+      "text": {{CreateBranchFormTitle}},
+      "horizontalAlignment": "Center",
+      "wrap": true,
+      "style": "heading"
+    },
+    {
+      "type": "Input.Text",
+      "id": "Repository",
+      "label": {{RepositoryLabel}},
+      "placeholder": {{RepositoryPlaceholder}},
+      "isRequired": true,
+      "errorMessage": {{RepositoryErrorMessage}},
+      "value": {{RepositoryValue}}
+    },
+    {
+      "type": "Input.Text",
+      "id": "NewBranch",
+      "label": {{NewBranchLabel}},
+      "placeholder": {{NewBranchPlaceholder}},
+      "isRequired": true,
+      "errorMessage": {{NewBranchErrorMessage}}
+    },
+    {
+      "type": "Input.Text",
+      "id": "SourceBranch",
+      "label": {{SourceBranchLabel}},
+      "placeholder": {{SourceBranchPlaceholder}},
+      "isRequired": true,
+      "errorMessage": {{SourceBranchErrorMessage}},
+      "value": {{SourceBranchValue}}
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.Submit",
+      "title": {{CreateBranchActionTitle}},
+      "data": {
+        "id": "CreateBranchAction"
+      }
+    }
+  ]
+}

--- a/GitHubExtension/Controls/Templates/CreateIssueTemplate.json
+++ b/GitHubExtension/Controls/Templates/CreateIssueTemplate.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "TextBlock",
+      "size": "Medium",
+      "weight": "Bolder",
+      "text": {{CreateIssueFormTitle}},
+      "horizontalAlignment": "Center",
+      "wrap": true,
+      "style": "heading"
+    },
+    {
+      "type": "Input.Text",
+      "id": "Repository",
+      "label": {{RepositoryLabel}},
+      "placeholder": {{RepositoryPlaceholder}},
+      "isRequired": true,
+      "errorMessage": {{RepositoryErrorMessage}},
+      "value": {{RepositoryValue}}
+    },
+    {
+      "type": "Input.Text",
+      "id": "Title",
+      "label": {{TitleLabel}},
+      "placeholder": {{TitlePlaceholder}},
+      "isRequired": true,
+      "errorMessage": {{TitleErrorMessage}}
+    },
+    {
+      "type": "Input.Text",
+      "id": "Body",
+      "label": {{BodyLabel}},
+      "placeholder": {{BodyPlaceholder}},
+      "isMultiline": true,
+      "isRequired": false
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.Submit",
+      "title": {{CreateIssueActionTitle}},
+      "data": {
+        "id": "CreateIssueAction"
+      }
+    }
+  ]
+}

--- a/GitHubExtension/Controls/Templates/CreatePullRequestTemplate.json
+++ b/GitHubExtension/Controls/Templates/CreatePullRequestTemplate.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "TextBlock",
+      "size": "Medium",
+      "weight": "Bolder",
+      "text": {{CreatePullRequestFormTitle}},
+      "horizontalAlignment": "Center",
+      "wrap": true,
+      "style": "heading"
+    },
+    {
+      "type": "Input.Text",
+      "id": "Repository",
+      "label": {{RepositoryLabel}},
+      "placeholder": {{RepositoryPlaceholder}},
+      "isRequired": true,
+      "errorMessage": {{RepositoryErrorMessage}},
+      "value": {{RepositoryValue}}
+    },
+    {
+      "type": "Input.Text",
+      "id": "Title",
+      "label": {{TitleLabel}},
+      "placeholder": {{TitlePlaceholder}},
+      "isRequired": true,
+      "errorMessage": {{TitleErrorMessage}}
+    },
+    {
+      "type": "Input.Text",
+      "id": "HeadBranch",
+      "label": {{HeadBranchLabel}},
+      "placeholder": {{HeadBranchPlaceholder}},
+      "isRequired": true,
+      "errorMessage": {{HeadBranchErrorMessage}}
+    },
+    {
+      "type": "Input.Text",
+      "id": "BaseBranch",
+      "label": {{BaseBranchLabel}},
+      "placeholder": {{BaseBranchPlaceholder}},
+      "isRequired": true,
+      "errorMessage": {{BaseBranchErrorMessage}},
+      "value": {{BaseBranchValue}}
+    },
+    {
+      "type": "Input.Text",
+      "id": "Body",
+      "label": {{BodyLabel}},
+      "placeholder": {{BodyPlaceholder}},
+      "isMultiline": true,
+      "isRequired": false
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.Submit",
+      "title": {{CreatePullRequestActionTitle}},
+      "data": {
+        "id": "CreatePullRequestAction"
+      }
+    }
+  ]
+}

--- a/GitHubExtension/DataManager/Data/GitHubCreateManager.cs
+++ b/GitHubExtension/DataManager/Data/GitHubCreateManager.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Client;
+using GitHubExtension.Controls;
+using Octokit;
+using Serilog;
+
+namespace GitHubExtension.DataManager.Data;
+
+public sealed class GitHubCreateManager : IGitHubCreateManager
+{
+    private static readonly Lazy<ILogger> _logger = new(() => Serilog.Log.ForContext("SourceContext", nameof(GitHubCreateManager)));
+
+    private static readonly ILogger _log = _logger.Value;
+
+    private readonly GitHubClientProvider _gitHubClientProvider;
+
+    public GitHubCreateManager(GitHubClientProvider gitHubClientProvider)
+    {
+        _gitHubClientProvider = gitHubClientProvider;
+    }
+
+    public async Task<string> CreateIssueAsync(string ownerRepo, string title, string body)
+    {
+        var (owner, repo) = ParseOwnerRepo(ownerRepo);
+        var client = await _gitHubClientProvider.GetClientForLoggedInDeveloper(false);
+        var newIssue = new NewIssue(title) { Body = body };
+        var created = await client.Issue.Create(owner, repo, newIssue);
+        _log.Information($"Created issue {owner}/{repo}#{created.Number}.");
+        return created.HtmlUrl;
+    }
+
+    public async Task<string> CreatePullRequestAsync(string ownerRepo, string title, string headBranch, string baseBranch, string body)
+    {
+        var (owner, repo) = ParseOwnerRepo(ownerRepo);
+        var client = await _gitHubClientProvider.GetClientForLoggedInDeveloper(false);
+        var newPullRequest = new NewPullRequest(title, headBranch, baseBranch) { Body = body };
+        var created = await client.PullRequest.Create(owner, repo, newPullRequest);
+        _log.Information($"Created pull request {owner}/{repo}#{created.Number}.");
+        return created.HtmlUrl;
+    }
+
+    public async Task<string> CreateBranchAsync(string ownerRepo, string newBranch, string sourceBranch)
+    {
+        var (owner, repo) = ParseOwnerRepo(ownerRepo);
+        var client = await _gitHubClientProvider.GetClientForLoggedInDeveloper(false);
+
+        var sourceReference = await client.Git.Reference.Get(owner, repo, $"heads/{sourceBranch}");
+        var newReference = new NewReference($"refs/heads/{newBranch}", sourceReference.Object.Sha);
+        var created = await client.Git.Reference.Create(owner, repo, newReference);
+        _log.Information($"Created branch {newBranch} in {owner}/{repo} from {sourceBranch}.");
+        return created.Ref;
+    }
+
+    public async Task AddCommentAsync(IIssue issue, string comment)
+    {
+        var owner = Validation.ParseOwnerFromGitHubURL(issue.HtmlUrl);
+        var repo = Validation.ParseRepositoryFromGitHubURL(issue.HtmlUrl);
+        var client = await _gitHubClientProvider.GetClientForLoggedInDeveloper(false);
+        await client.Issue.Comment.Create(owner, repo, (int)issue.Number, comment);
+        _log.Information($"Added comment to {owner}/{repo}#{issue.Number}.");
+    }
+
+    internal static (string Owner, string Repo) ParseOwnerRepo(string ownerRepo)
+    {
+        if (string.IsNullOrWhiteSpace(ownerRepo))
+        {
+            throw new ArgumentException("Repository must be provided as owner/repo.", nameof(ownerRepo));
+        }
+
+        var trimmed = ownerRepo.Trim();
+
+        // Accept a full GitHub URL as well as the short owner/repo form.
+        if (Validation.IsValidHttpUri(trimmed, out var uri) && uri != null)
+        {
+            return (Validation.ParseOwnerFromGitHubURL(uri), Validation.ParseRepositoryFromGitHubURL(uri));
+        }
+
+        var parts = trimmed.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length != 2)
+        {
+            throw new ArgumentException("Repository must be in the form owner/repo.", nameof(ownerRepo));
+        }
+
+        return (parts[0], parts[1]);
+    }
+}

--- a/GitHubExtension/DataManager/IGitHubCreateManager.cs
+++ b/GitHubExtension/DataManager/IGitHubCreateManager.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Controls;
+
+namespace GitHubExtension.DataManager;
+
+// Performs create/write operations that produce new GitHub resources (issues,
+// pull requests, branches) plus comments on existing items. Kept separate from
+// the read-only cache path and from the state-mutation manager. Introduced in
+// M4 (create flows) and reused by later milestones.
+public interface IGitHubCreateManager
+{
+    Task<string> CreateIssueAsync(string ownerRepo, string title, string body);
+
+    Task<string> CreatePullRequestAsync(string ownerRepo, string title, string headBranch, string baseBranch, string body);
+
+    Task<string> CreateBranchAsync(string ownerRepo, string newBranch, string sourceBranch);
+
+    Task AddCommentAsync(IIssue issue, string comment);
+}

--- a/GitHubExtension/GitHubExtensionCommandsProvider.cs
+++ b/GitHubExtension/GitHubExtensionCommandsProvider.cs
@@ -4,7 +4,9 @@
 
 using System.Diagnostics;
 using GitHubExtension.Controls;
+using GitHubExtension.Controls.Forms;
 using GitHubExtension.Controls.Pages;
+using GitHubExtension.DataManager;
 using GitHubExtension.DeveloperIds;
 using GitHubExtension.Helpers;
 using Microsoft.CommandPalette.Extensions;
@@ -25,6 +27,7 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
     private readonly SavedSearchesMediator _savedSearchesMediator;
     private readonly AuthenticationMediator _authenticationMediator;
     private readonly NotificationsMediator _notificationsMediator;
+    private readonly IGitHubCreateManager _createManager;
 
     public GitHubExtensionCommandsProvider(
         SavedSearchesPage savedSearchesPage,
@@ -37,7 +40,8 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
         ISearchPageFactory searchPageFactory,
         SavedSearchesMediator savedSearchesMediator,
         AuthenticationMediator authenticationMediator,
-        NotificationsMediator notificationsMediator)
+        NotificationsMediator notificationsMediator,
+        IGitHubCreateManager createManager)
     {
         _savedSearchesPage = savedSearchesPage;
         _signOutPage = signOutPage;
@@ -50,6 +54,7 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
         _savedSearchesMediator = savedSearchesMediator;
         _authenticationMediator = authenticationMediator;
         _notificationsMediator = notificationsMediator;
+        _createManager = createManager;
 
         DisplayName = _resources.GetResource("ExtensionTitle");
 
@@ -106,12 +111,66 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
         var defaultCommands = new List<CommandItem>
         {
             BuildNotificationsCommandItem(),
+            BuildCreateIssueCommandItem(),
+            BuildCreatePullRequestCommandItem(),
+            BuildCreateBranchCommandItem(),
             new(_savedSearchesPage),
             new(_signOutPage),
         };
 
         commands.AddRange(defaultCommands);
         return commands.ToArray();
+    }
+
+    private CommandItem BuildCreateIssueCommandItem()
+    {
+        var page = new GitHubFormPage(
+            new CreateIssueForm(_createManager, _resources),
+            _resources,
+            "Forms_CreateIssue_Title",
+            "\uE710",
+            "Message_CreateIssue_Success",
+            "Message_CreateIssue_Error");
+
+        return new CommandItem(page)
+        {
+            Title = _resources.GetResource("CommandsProvider_CreateIssueCommandName"),
+            Subtitle = _resources.GetResource("CommandsProvider_CreateIssueSubtitle"),
+        };
+    }
+
+    private CommandItem BuildCreatePullRequestCommandItem()
+    {
+        var page = new GitHubFormPage(
+            new CreatePullRequestForm(_createManager, _resources),
+            _resources,
+            "Forms_CreatePullRequest_Title",
+            "\uE710",
+            "Message_CreatePullRequest_Success",
+            "Message_CreatePullRequest_Error");
+
+        return new CommandItem(page)
+        {
+            Title = _resources.GetResource("CommandsProvider_CreatePullRequestCommandName"),
+            Subtitle = _resources.GetResource("CommandsProvider_CreatePullRequestSubtitle"),
+        };
+    }
+
+    private CommandItem BuildCreateBranchCommandItem()
+    {
+        var page = new GitHubFormPage(
+            new CreateBranchForm(_createManager, _resources),
+            _resources,
+            "Forms_CreateBranch_Title",
+            "\uE710",
+            "Message_CreateBranch_Success",
+            "Message_CreateBranch_Error");
+
+        return new CommandItem(page)
+        {
+            Title = _resources.GetResource("CommandsProvider_CreateBranchCommandName"),
+            Subtitle = _resources.GetResource("CommandsProvider_CreateBranchSubtitle"),
+        };
     }
 
     private CommandItem BuildNotificationsCommandItem()

--- a/GitHubExtension/Helpers/TemplateHelper.cs
+++ b/GitHubExtension/Helpers/TemplateHelper.cs
@@ -14,6 +14,10 @@ public static class TemplateHelper
         {
             "AuthTemplate" => "Controls\\Templates\\AuthTemplate.json",
             "SaveSearch" => "Controls\\Templates\\SaveSearchTemplate.json",
+            "CreateIssue" => "Controls\\Templates\\CreateIssueTemplate.json",
+            "CreatePullRequest" => "Controls\\Templates\\CreatePullRequestTemplate.json",
+            "CreateBranch" => "Controls\\Templates\\CreateBranchTemplate.json",
+            "AddComment" => "Controls\\Templates\\AddCommentTemplate.json",
             _ => throw new NotImplementedException($"Template for page '{page}' is not implemented."),
         };
     }

--- a/GitHubExtension/Program.cs
+++ b/GitHubExtension/Program.cs
@@ -138,7 +138,8 @@ public class Program
         var notificationsPage = new NotificationsPage(notificationsDataManager, notificationsMediator, resources);
 
         var mutationManager = new GitHubMutationManager(gitHubClientProvider);
-        var mutationCommandsFactory = new MutationCommandsFactory(mutationManager, mutationMediator, resources);
+        var createManager = new GitHubCreateManager(gitHubClientProvider);
+        var mutationCommandsFactory = new MutationCommandsFactory(mutationManager, createManager, mutationMediator, resources);
 
         var searchPageFactory = new SearchPageFactory(cacheDataManager, searchRepository, resources, savedSearchesMediator, mutationCommandsFactory, mutationMediator);
 
@@ -154,7 +155,7 @@ public class Program
         using var signInForm = new SignInForm(authenticationMediator, resources, developerIdProvider, signInCommand);
         using var signInPage = new SignInPage(signInForm, resources, signInCommand, authenticationMediator);
 
-        using var commandProvider = new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, notificationsPage, developerIdProvider, searchRepository, resources, searchPageFactory, savedSearchesMediator, authenticationMediator, notificationsMediator);
+        using var commandProvider = new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, notificationsPage, developerIdProvider, searchRepository, resources, searchPageFactory, savedSearchesMediator, authenticationMediator, notificationsMediator, createManager);
         var extensionInstance = new GitHubExtension(extensionDisposedEvent, commandProvider);
 
         // We are instantiating an extension instance once above, and returning it every time the callback in RegisterExtension below is called.

--- a/GitHubExtension/Strings/en-US/Resources.resw
+++ b/GitHubExtension/Strings/en-US/Resources.resw
@@ -445,6 +445,186 @@
     <value>This will merge the pull request into its base branch.</value>
     <comment>Confirmation description before merging a pull request</comment>
   </data>
+  <data name="CommandsProvider_CreateIssueCommandName" xml:space="preserve">
+    <value>Create Issue</value>
+    <comment>Top-level command name for creating an issue</comment>
+  </data>
+  <data name="CommandsProvider_CreateIssueSubtitle" xml:space="preserve">
+    <value>Open a new issue on GitHub</value>
+    <comment>Subtitle for the Create Issue top-level command</comment>
+  </data>
+  <data name="CommandsProvider_CreatePullRequestCommandName" xml:space="preserve">
+    <value>Create Pull Request</value>
+    <comment>Top-level command name for creating a pull request</comment>
+  </data>
+  <data name="CommandsProvider_CreatePullRequestSubtitle" xml:space="preserve">
+    <value>Open a new pull request on GitHub</value>
+    <comment>Subtitle for the Create Pull Request top-level command</comment>
+  </data>
+  <data name="CommandsProvider_CreateBranchCommandName" xml:space="preserve">
+    <value>Create Branch</value>
+    <comment>Top-level command name for creating a branch</comment>
+  </data>
+  <data name="CommandsProvider_CreateBranchSubtitle" xml:space="preserve">
+    <value>Create a new branch on GitHub</value>
+    <comment>Subtitle for the Create Branch top-level command</comment>
+  </data>
+  <data name="Forms_Create_RepositoryLabel" xml:space="preserve">
+    <value>Repository</value>
+    <comment>Label for the repository input on create forms</comment>
+  </data>
+  <data name="Forms_Create_RepositoryPlaceholder" xml:space="preserve">
+    <value>owner/repo</value>
+    <comment>Placeholder for the repository input on create forms</comment>
+  </data>
+  <data name="Forms_Create_RepositoryError" xml:space="preserve">
+    <value>Enter a repository as owner/repo</value>
+    <comment>Validation error for the repository input on create forms</comment>
+  </data>
+  <data name="Forms_Create_TitleLabel" xml:space="preserve">
+    <value>Title</value>
+    <comment>Label for the title input on create forms</comment>
+  </data>
+  <data name="Forms_Create_TitlePlaceholder" xml:space="preserve">
+    <value>Enter a title</value>
+    <comment>Placeholder for the title input on create forms</comment>
+  </data>
+  <data name="Forms_Create_TitleError" xml:space="preserve">
+    <value>A title is required</value>
+    <comment>Validation error for the title input on create forms</comment>
+  </data>
+  <data name="Forms_Create_BodyLabel" xml:space="preserve">
+    <value>Description</value>
+    <comment>Label for the body input on create forms</comment>
+  </data>
+  <data name="Forms_Create_BodyPlaceholder" xml:space="preserve">
+    <value>Enter a description (optional)</value>
+    <comment>Placeholder for the body input on create forms</comment>
+  </data>
+  <data name="Forms_CreateIssue_Title" xml:space="preserve">
+    <value>Create Issue</value>
+    <comment>Title for the create issue form</comment>
+  </data>
+  <data name="Forms_CreateIssue_Action" xml:space="preserve">
+    <value>Create issue</value>
+    <comment>Submit action title for the create issue form</comment>
+  </data>
+  <data name="Forms_CreatePullRequest_Title" xml:space="preserve">
+    <value>Create Pull Request</value>
+    <comment>Title for the create pull request form</comment>
+  </data>
+  <data name="Forms_CreatePullRequest_Action" xml:space="preserve">
+    <value>Create pull request</value>
+    <comment>Submit action title for the create pull request form</comment>
+  </data>
+  <data name="Forms_CreatePullRequest_HeadLabel" xml:space="preserve">
+    <value>Head branch</value>
+    <comment>Label for the head branch input on the create pull request form</comment>
+  </data>
+  <data name="Forms_CreatePullRequest_HeadPlaceholder" xml:space="preserve">
+    <value>feature-branch</value>
+    <comment>Placeholder for the head branch input on the create pull request form</comment>
+  </data>
+  <data name="Forms_CreatePullRequest_HeadError" xml:space="preserve">
+    <value>A head branch is required</value>
+    <comment>Validation error for the head branch input on the create pull request form</comment>
+  </data>
+  <data name="Forms_CreatePullRequest_BaseLabel" xml:space="preserve">
+    <value>Base branch</value>
+    <comment>Label for the base branch input on the create pull request form</comment>
+  </data>
+  <data name="Forms_CreatePullRequest_BasePlaceholder" xml:space="preserve">
+    <value>main</value>
+    <comment>Placeholder for the base branch input on the create pull request form</comment>
+  </data>
+  <data name="Forms_CreatePullRequest_BaseError" xml:space="preserve">
+    <value>A base branch is required</value>
+    <comment>Validation error for the base branch input on the create pull request form</comment>
+  </data>
+  <data name="Forms_CreateBranch_Title" xml:space="preserve">
+    <value>Create Branch</value>
+    <comment>Title for the create branch form</comment>
+  </data>
+  <data name="Forms_CreateBranch_Action" xml:space="preserve">
+    <value>Create branch</value>
+    <comment>Submit action title for the create branch form</comment>
+  </data>
+  <data name="Forms_CreateBranch_NewBranchLabel" xml:space="preserve">
+    <value>New branch name</value>
+    <comment>Label for the new branch input on the create branch form</comment>
+  </data>
+  <data name="Forms_CreateBranch_NewBranchPlaceholder" xml:space="preserve">
+    <value>feature-branch</value>
+    <comment>Placeholder for the new branch input on the create branch form</comment>
+  </data>
+  <data name="Forms_CreateBranch_NewBranchError" xml:space="preserve">
+    <value>A branch name is required</value>
+    <comment>Validation error for the new branch input on the create branch form</comment>
+  </data>
+  <data name="Forms_CreateBranch_SourceBranchLabel" xml:space="preserve">
+    <value>Source branch</value>
+    <comment>Label for the source branch input on the create branch form</comment>
+  </data>
+  <data name="Forms_CreateBranch_SourceBranchPlaceholder" xml:space="preserve">
+    <value>main</value>
+    <comment>Placeholder for the source branch input on the create branch form</comment>
+  </data>
+  <data name="Forms_CreateBranch_SourceBranchError" xml:space="preserve">
+    <value>A source branch is required</value>
+    <comment>Validation error for the source branch input on the create branch form</comment>
+  </data>
+  <data name="Forms_AddComment_Title" xml:space="preserve">
+    <value>Add Comment</value>
+    <comment>Title for the add comment form</comment>
+  </data>
+  <data name="Forms_AddComment_Action" xml:space="preserve">
+    <value>Add comment</value>
+    <comment>Submit action title for the add comment form</comment>
+  </data>
+  <data name="Forms_AddComment_BodyLabel" xml:space="preserve">
+    <value>Comment</value>
+    <comment>Label for the comment input on the add comment form</comment>
+  </data>
+  <data name="Forms_AddComment_BodyPlaceholder" xml:space="preserve">
+    <value>Write a comment</value>
+    <comment>Placeholder for the comment input on the add comment form</comment>
+  </data>
+  <data name="Forms_AddComment_BodyError" xml:space="preserve">
+    <value>A comment is required</value>
+    <comment>Validation error for the comment input on the add comment form</comment>
+  </data>
+  <data name="Message_CreateIssue_Success" xml:space="preserve">
+    <value>Issue created</value>
+    <comment>Toast shown after an issue is created</comment>
+  </data>
+  <data name="Message_CreateIssue_Error" xml:space="preserve">
+    <value>Failed to create issue</value>
+    <comment>Toast shown when creating an issue fails</comment>
+  </data>
+  <data name="Message_CreatePullRequest_Success" xml:space="preserve">
+    <value>Pull request created</value>
+    <comment>Toast shown after a pull request is created</comment>
+  </data>
+  <data name="Message_CreatePullRequest_Error" xml:space="preserve">
+    <value>Failed to create pull request</value>
+    <comment>Toast shown when creating a pull request fails</comment>
+  </data>
+  <data name="Message_CreateBranch_Success" xml:space="preserve">
+    <value>Branch created</value>
+    <comment>Toast shown after a branch is created</comment>
+  </data>
+  <data name="Message_CreateBranch_Error" xml:space="preserve">
+    <value>Failed to create branch</value>
+    <comment>Toast shown when creating a branch fails</comment>
+  </data>
+  <data name="Message_AddComment_Success" xml:space="preserve">
+    <value>Comment added</value>
+    <comment>Toast shown after a comment is added</comment>
+  </data>
+  <data name="Message_AddComment_Error" xml:space="preserve">
+    <value>Failed to add comment</value>
+    <comment>Toast shown when adding a comment fails</comment>
+  </data>
   <data name="ExtensionTitle" xml:space="preserve">
     <value>GitHub Extension (Preview)</value>
     <comment>Title for the extension</comment>


### PR DESCRIPTION
Part of the CmdPal GitHub extension parity roadmap (stacked on M3, PR #290).

## Summary
Adds create/write flows built on \FormContent\, plus the Add Comment action deferred from M3.

### Create manager
- \IGitHubCreateManager\ / \GitHubCreateManager\ (Octokit REST): create issue, create pull request, create branch (resolves the source ref SHA then creates \efs/heads/...\), and add a comment to an issue/PR.
- \ParseOwnerRepo\ accepts both the short \owner/repo\ form and a full GitHub URL.

### Forms, templates, and pages
- Adaptive-card forms: \CreateIssueForm\, \CreatePullRequestForm\, \CreateBranchForm\, \AddCommentForm\, each with its own template under \Controls/Templates\.
- Required-field validation via the card; success/error toasts through \FormEventHelper\.
- Reusable \GitHubFormPage\ host wires each form to a \StatusMessage\.

### Command surface
- Top-level commands: **Create Issue**, **Create Pull Request**, **Create Branch**.
- **Add Comment** wired into the issue/PR list and detail views via the existing \MutationCommandsFactory\ (which now also holds the create manager), fulfilling the M3 deferral.

## Design note
Repository and branch entry is text-input based (\owner/repo\, branch names) rather than API-populated dropdowns. Dynamic pickers can be a later enhancement once a shared repo/branch lookup exists.

## Tests
- \CreateFormsTests\: each form renders valid adaptive-card JSON (exercises templates + substitutions).
- \GitHubCreateManagerTests\: owner/repo parsing (short form, URL, whitespace, error cases).
- Updated factory tests for the added Add Comment command.
- Full suite: 186/186 passing. Build clean (x64 Debug).

## Localization
Added top-level command names/subtitles, form labels/placeholders/validation errors, action titles, and success/error toasts to \Resources.resw\.