### PR TITLE
M5: Workflow runs (list + re-run/cancel/trigger)

### DIFF
--- a/GitHubExtension.Test/Controls/WorkflowRunsTests.cs
+++ b/GitHubExtension.Test/Controls/WorkflowRunsTests.cs
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using GitHubExtension.Controls;
+using GitHubExtension.Controls.Forms;
+using GitHubExtension.Controls.Pages;
+using GitHubExtension.DataManager;
+using GitHubExtension.Helpers;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Moq;
+
+namespace GitHubExtension.Test.Controls;
+
+[TestClass]
+public class WorkflowRunsTests
+{
+    private static Mock<IResources> CreateResources()
+    {
+        var resources = new Mock<IResources>();
+        resources.Setup(x => x.GetResource(It.IsAny<string>(), null)).Returns<string, object>((key, _) => key);
+        return resources;
+    }
+
+    private static Mock<IWorkflowRun> CreateRun(long id, string status, string conclusion)
+    {
+        var run = new Mock<IWorkflowRun>();
+        run.Setup(x => x.Id).Returns(id);
+        run.Setup(x => x.Name).Returns("CI");
+        run.Setup(x => x.RunNumber).Returns(id);
+        run.Setup(x => x.Status).Returns(status);
+        run.Setup(x => x.Conclusion).Returns(conclusion);
+        run.Setup(x => x.HeadBranch).Returns("main");
+        run.Setup(x => x.HtmlUrl).Returns($"https://github.com/owner/repo/actions/runs/{id}");
+        return run;
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void TriggerWorkflowForm_TemplateJson_IsValidJson()
+    {
+        var dataManager = new Mock<IWorkflowRunsDataManager>();
+        var form = new TriggerWorkflowForm(dataManager.Object, CreateResources().Object, "owner/repo");
+
+        var json = form.TemplateJson;
+
+        var parsed = JsonDocument.Parse(json);
+        Assert.AreEqual("AdaptiveCard", parsed.RootElement.GetProperty("type").GetString());
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void WorkflowRunsPage_EmptyQuery_ShowsPrompt()
+    {
+        var dataManager = new Mock<IWorkflowRunsDataManager>();
+        var page = new WorkflowRunsPage(dataManager.Object, new WorkflowRunsMediator(), CreateResources().Object);
+
+        var items = page.GetItems();
+
+        Assert.AreEqual(1, items.Length);
+        Assert.AreEqual("Pages_WorkflowRuns_Prompt", items[0].Title);
+        dataManager.Verify(x => x.GetWorkflowRunsAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void WorkflowRunsPage_WithRuns_ReturnsItems()
+    {
+        var dataManager = new Mock<IWorkflowRunsDataManager>();
+        dataManager.Setup(x => x.GetWorkflowRunsAsync("owner/repo"))
+            .ReturnsAsync(new[] { CreateRun(1, "completed", "success").Object, CreateRun(2, "completed", "failure").Object });
+
+        var page = new WorkflowRunsPage(dataManager.Object, new WorkflowRunsMediator(), CreateResources().Object)
+        {
+            SearchText = "owner/repo",
+        };
+
+        var items = page.GetItems();
+
+        Assert.AreEqual(2, items.Length);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void WorkflowRunsPage_InProgressRun_HasCancelCommand()
+    {
+        var dataManager = new Mock<IWorkflowRunsDataManager>();
+        dataManager.Setup(x => x.GetWorkflowRunsAsync("owner/repo"))
+            .ReturnsAsync(new[] { CreateRun(1, "in_progress", string.Empty).Object });
+
+        var page = new WorkflowRunsPage(dataManager.Object, new WorkflowRunsMediator(), CreateResources().Object)
+        {
+            SearchText = "owner/repo",
+        };
+
+        var item = (ListItem)page.GetItems()[0];
+
+        // Re-run + Cancel + Copy URL
+        Assert.AreEqual(3, item.MoreCommands.Length);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void WorkflowRunsPage_CompletedRun_HasNoCancelCommand()
+    {
+        var dataManager = new Mock<IWorkflowRunsDataManager>();
+        dataManager.Setup(x => x.GetWorkflowRunsAsync("owner/repo"))
+            .ReturnsAsync(new[] { CreateRun(1, "completed", "success").Object });
+
+        var page = new WorkflowRunsPage(dataManager.Object, new WorkflowRunsMediator(), CreateResources().Object)
+        {
+            SearchText = "owner/repo",
+        };
+
+        var item = (ListItem)page.GetItems()[0];
+
+        // Re-run + Copy URL (no cancel for a completed run)
+        Assert.AreEqual(2, item.MoreCommands.Length);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void WorkflowRunsPage_NoRuns_ShowsNoneMessage()
+    {
+        var dataManager = new Mock<IWorkflowRunsDataManager>();
+        dataManager.Setup(x => x.GetWorkflowRunsAsync("owner/repo"))
+            .ReturnsAsync(Array.Empty<IWorkflowRun>());
+
+        var page = new WorkflowRunsPage(dataManager.Object, new WorkflowRunsMediator(), CreateResources().Object)
+        {
+            SearchText = "owner/repo",
+        };
+
+        var items = page.GetItems();
+
+        Assert.AreEqual(1, items.Length);
+        Assert.AreEqual("Pages_WorkflowRuns_None", items[0].Title);
+    }
+}

--- a/GitHubExtension.Test/Helpers/TestSetupHelpers.cs
+++ b/GitHubExtension.Test/Helpers/TestSetupHelpers.cs
@@ -176,6 +176,9 @@ public partial class TestHelpers
         mockNotificationsDataManager.Setup(x => x.GetUnreadCountAsync()).ReturnsAsync(0);
         var notificationsPage = new NotificationsPage(mockNotificationsDataManager.Object, notificationsMediator, mockResources);
         var mockCreateManager = new Mock<IGitHubCreateManager>().Object;
-        return new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, notificationsPage, mockDeveloperIdProvider, persistentDataManager, mockResources, searchPageFactory, savedSearchesMediator, mockAuthenticationMediator, notificationsMediator, mockCreateManager);
+        var workflowRunsMediator = new WorkflowRunsMediator();
+        var mockWorkflowRunsDataManager = new Mock<IWorkflowRunsDataManager>();
+        var workflowRunsPage = new WorkflowRunsPage(mockWorkflowRunsDataManager.Object, workflowRunsMediator, mockResources);
+        return new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, notificationsPage, mockDeveloperIdProvider, persistentDataManager, mockResources, searchPageFactory, savedSearchesMediator, mockAuthenticationMediator, notificationsMediator, mockCreateManager, workflowRunsPage, mockWorkflowRunsDataManager.Object);
     }
 }

--- a/GitHubExtension/Controls/Commands/LinkCommand.cs
+++ b/GitHubExtension/Controls/Commands/LinkCommand.cs
@@ -40,6 +40,13 @@ internal sealed partial class LinkCommand : InvokableCommand
         Icon = new IconInfo("\uE8A7");
     }
 
+    internal LinkCommand(string htmlUrl, IResources resources)
+    {
+        _htmlUrl = htmlUrl;
+        Name = resources.GetResource("Commands_Open_Link");
+        Icon = new IconInfo("\uE8A7");
+    }
+
     public override CommandResult Invoke()
     {
         Process.Start(new ProcessStartInfo(_htmlUrl) { UseShellExecute = true });

--- a/GitHubExtension/Controls/Commands/WorkflowRunActionCommand.cs
+++ b/GitHubExtension/Controls/Commands/WorkflowRunActionCommand.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.DataManager;
+using GitHubExtension.Helpers;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Serilog;
+
+namespace GitHubExtension.Controls.Commands;
+
+// Runs a workflow-run action (re-run or cancel) against GitHub, showing a
+// success or error toast and notifying the workflow-runs mediator so the open
+// page can refresh. Non-destructive actions use this command directly;
+// destructive actions wrap it in a ConfirmedCommand.
+internal sealed partial class WorkflowRunActionCommand : InvokableCommand
+{
+    private static readonly ILogger _log = Log.ForContext("SourceContext", nameof(WorkflowRunActionCommand));
+
+    private readonly Func<Task> _action;
+    private readonly string _successMessage;
+    private readonly string _errorMessage;
+    private readonly WorkflowRunsMediator _mediator;
+
+    internal WorkflowRunActionCommand(string name, IconInfo icon, Func<Task> action, string successMessage, string errorMessage, WorkflowRunsMediator mediator)
+    {
+        Name = name;
+        Icon = icon;
+        _action = action;
+        _successMessage = successMessage;
+        _errorMessage = errorMessage;
+        _mediator = mediator;
+    }
+
+    public override CommandResult Invoke()
+    {
+        try
+        {
+            _action().GetAwaiter().GetResult();
+            ToastHelper.ShowSuccessToast(_successMessage);
+            _mediator.NotifyWorkflowRunsChanged();
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Workflow run action failed.");
+            ToastHelper.ShowErrorToast(_errorMessage);
+        }
+
+        return CommandResult.KeepOpen();
+    }
+}

--- a/GitHubExtension/Controls/Forms/TriggerWorkflowForm.cs
+++ b/GitHubExtension/Controls/Forms/TriggerWorkflowForm.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using GitHubExtension.DataManager;
+using GitHubExtension.Helpers;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace GitHubExtension.Controls.Forms;
+
+public sealed partial class TriggerWorkflowForm : FormContent, IGitHubForm
+{
+    private readonly IWorkflowRunsDataManager _dataManager;
+    private readonly IResources _resources;
+    private readonly string _initialRepository;
+
+    public event EventHandler<bool>? LoadingStateChanged;
+
+    public event EventHandler<FormSubmitEventArgs>? FormSubmitted;
+
+    public TriggerWorkflowForm(IWorkflowRunsDataManager dataManager, IResources resources, string initialRepository = "")
+    {
+        _dataManager = dataManager;
+        _resources = resources;
+        _initialRepository = initialRepository;
+    }
+
+    public Dictionary<string, string> TemplateSubstitutions => new()
+    {
+        { "{{TriggerWorkflowFormTitle}}", JsonSerializer.Serialize(_resources.GetResource("Forms_TriggerWorkflow_Title")) },
+        { "{{RepositoryLabel}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Create_RepositoryLabel")) },
+        { "{{RepositoryPlaceholder}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Create_RepositoryPlaceholder")) },
+        { "{{RepositoryErrorMessage}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Create_RepositoryError")) },
+        { "{{RepositoryValue}}", JsonSerializer.Serialize(_initialRepository) },
+        { "{{WorkflowFileLabel}}", JsonSerializer.Serialize(_resources.GetResource("Forms_TriggerWorkflow_WorkflowFileLabel")) },
+        { "{{WorkflowFilePlaceholder}}", JsonSerializer.Serialize(_resources.GetResource("Forms_TriggerWorkflow_WorkflowFilePlaceholder")) },
+        { "{{WorkflowFileErrorMessage}}", JsonSerializer.Serialize(_resources.GetResource("Forms_TriggerWorkflow_WorkflowFileError")) },
+        { "{{RefLabel}}", JsonSerializer.Serialize(_resources.GetResource("Forms_TriggerWorkflow_RefLabel")) },
+        { "{{RefPlaceholder}}", JsonSerializer.Serialize(_resources.GetResource("Forms_TriggerWorkflow_RefPlaceholder")) },
+        { "{{RefErrorMessage}}", JsonSerializer.Serialize(_resources.GetResource("Forms_TriggerWorkflow_RefError")) },
+        { "{{RefValue}}", JsonSerializer.Serialize("main") },
+        { "{{TriggerWorkflowActionTitle}}", JsonSerializer.Serialize(_resources.GetResource("Forms_TriggerWorkflow_Action")) },
+    };
+
+    public override string TemplateJson => TemplateHelper.LoadTemplateJsonFromTemplateName("TriggerWorkflow", TemplateSubstitutions);
+
+    public override ICommandResult SubmitForm(string? inputs, string data)
+    {
+        LoadingStateChanged?.Invoke(this, true);
+        _ = SubmitInternalAsync(inputs);
+        return CommandResult.KeepOpen();
+    }
+
+    private async Task SubmitInternalAsync(string? inputs)
+    {
+        try
+        {
+            var payload = JsonNode.Parse(inputs ?? string.Empty) ?? throw new InvalidOperationException("No input provided.");
+            var repository = payload["Repository"]?.ToString() ?? string.Empty;
+            var workflowFile = payload["WorkflowFile"]?.ToString() ?? string.Empty;
+            var gitRef = payload["Ref"]?.ToString() ?? string.Empty;
+
+            await _dataManager.TriggerWorkflowAsync(repository, workflowFile, gitRef);
+
+            LoadingStateChanged?.Invoke(this, false);
+            FormSubmitted?.Invoke(this, new FormSubmitEventArgs(true, null));
+        }
+        catch (Exception ex)
+        {
+            LoadingStateChanged?.Invoke(this, false);
+            FormSubmitted?.Invoke(this, new FormSubmitEventArgs(false, ex));
+        }
+    }
+}

--- a/GitHubExtension/Controls/IWorkflowRun.cs
+++ b/GitHubExtension/Controls/IWorkflowRun.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace GitHubExtension.Controls;
+
+public interface IWorkflowRun
+{
+    long Id { get; }
+
+    string Name { get; }
+
+    string Status { get; }
+
+    string Conclusion { get; }
+
+    string HeadBranch { get; }
+
+    string TriggerEvent { get; }
+
+    long RunNumber { get; }
+
+    string HtmlUrl { get; }
+
+    string RepositoryFullName { get; }
+
+    DateTimeOffset CreatedAt { get; }
+}

--- a/GitHubExtension/Controls/Pages/WorkflowRunsPage.cs
+++ b/GitHubExtension/Controls/Pages/WorkflowRunsPage.cs
@@ -1,0 +1,172 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Controls.Commands;
+using GitHubExtension.DataManager;
+using GitHubExtension.Helpers;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Serilog;
+
+namespace GitHubExtension.Controls.Pages;
+
+// Repository-scoped workflow runs page. Because workflow runs require a
+// repository, the user types owner/repo into the search box and the page loads
+// the most recent runs for that repository. Per-run actions include re-run
+// (non-destructive) and cancel (destructive, confirmed), plus open in browser
+// and copy URL.
+public sealed partial class WorkflowRunsPage : DynamicListPage
+{
+    private readonly IWorkflowRunsDataManager _dataManager;
+    private readonly WorkflowRunsMediator _mediator;
+    private readonly IResources _resources;
+    private readonly ILogger _log;
+
+    public WorkflowRunsPage(IWorkflowRunsDataManager dataManager, WorkflowRunsMediator mediator, IResources resources)
+    {
+        _dataManager = dataManager;
+        _mediator = mediator;
+        _resources = resources;
+        _log = Log.ForContext("SourceContext", $"Pages/{nameof(WorkflowRunsPage)}");
+
+        Name = resources.GetResource("Pages_WorkflowRuns");
+        Icon = GitHubIcon.IconDictionary["Workflows"];
+        PlaceholderText = resources.GetResource("Pages_WorkflowRuns_Placeholder");
+
+        _mediator.WorkflowRunsChanged += OnWorkflowRunsChanged;
+    }
+
+    private void OnWorkflowRunsChanged(object? sender, object? args)
+    {
+        RaiseItemsChanged(0);
+    }
+
+    public override void UpdateSearchText(string oldSearch, string newSearch)
+    {
+        RaiseItemsChanged(0);
+    }
+
+    public override IListItem[] GetItems() => DoGetItems(SearchText).GetAwaiter().GetResult();
+
+    private async Task<IListItem[]> DoGetItems(string query)
+    {
+        var repository = (query ?? string.Empty).Trim();
+
+        if (string.IsNullOrEmpty(repository))
+        {
+            return new IListItem[]
+            {
+                new ListItem(new NoOpCommand())
+                {
+                    Title = _resources.GetResource("Pages_WorkflowRuns_Prompt"),
+                    Icon = GitHubIcon.IconDictionary["Workflows"],
+                },
+            };
+        }
+
+        try
+        {
+            var runs = (await _dataManager.GetWorkflowRunsAsync(repository)).ToList();
+
+            if (runs.Count == 0)
+            {
+                return new IListItem[]
+                {
+                    new ListItem(new NoOpCommand())
+                    {
+                        Title = _resources.GetResource("Pages_WorkflowRuns_None"),
+                        Icon = GitHubIcon.IconDictionary["Workflows"],
+                    },
+                };
+            }
+
+            return runs.Select(run => GetListItem(repository, run)).ToArray();
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to load workflow runs.");
+            return new IListItem[]
+            {
+                new ListItem(new NoOpCommand())
+                {
+                    Title = _resources.GetResource("Pages_Error_Title"),
+                    Details = new Details()
+                    {
+                        Title = ex.Message,
+                        Body = string.IsNullOrEmpty(ex.StackTrace) ? "There is no stack trace for the error." : ex.StackTrace,
+                    },
+                },
+            };
+        }
+    }
+
+    private ListItem GetListItem(string repository, IWorkflowRun run)
+    {
+        var rerunCommand = new WorkflowRunActionCommand(
+            _resources.GetResource("Commands_RerunWorkflow"),
+            new IconInfo("\uE72C"),
+            () => _dataManager.RerunAsync(repository, run.Id),
+            _resources.GetResource("Message_RerunWorkflow_Success"),
+            _resources.GetResource("Message_RerunWorkflow_Error"),
+            _mediator);
+
+        var cancelInner = new WorkflowRunActionCommand(
+            _resources.GetResource("Commands_CancelWorkflow"),
+            new IconInfo("\uE711"),
+            () => _dataManager.CancelAsync(repository, run.Id),
+            _resources.GetResource("Message_CancelWorkflow_Success"),
+            _resources.GetResource("Message_CancelWorkflow_Error"),
+            _mediator);
+
+        var cancelCommand = new ConfirmedCommand(
+            cancelInner,
+            _resources.GetResource("Commands_CancelWorkflow"),
+            new IconInfo("\uE711"),
+            _resources.GetResource("Confirm_CancelWorkflow_Title"),
+            _resources.GetResource("Confirm_CancelWorkflow_Description"));
+
+        var moreCommands = new List<CommandContextItem>
+        {
+            new(rerunCommand),
+        };
+
+        if (IsCancellable(run.Status))
+        {
+            moreCommands.Add(new CommandContextItem(cancelCommand) { IsCritical = true });
+        }
+
+        moreCommands.Add(new CommandContextItem(new CopyCommand(run.HtmlUrl, _resources.GetResource("Commands_CopyURL"), _resources)));
+
+        return new ListItem(new LinkCommand(run.HtmlUrl, _resources))
+        {
+            Title = GetTitle(run),
+            Subtitle = GetSubtitle(run),
+            Icon = GitHubIcon.IconDictionary["Workflows"],
+            MoreCommands = moreCommands.ToArray(),
+        };
+    }
+
+    private string GetTitle(IWorkflowRun run)
+    {
+        var name = string.IsNullOrEmpty(run.Name) ? _resources.GetResource("Pages_WorkflowRuns_UnnamedRun") : run.Name;
+        return $"{name} #{run.RunNumber}";
+    }
+
+    private string GetSubtitle(IWorkflowRun run)
+    {
+        var state = string.IsNullOrEmpty(run.Conclusion) ? run.Status : run.Conclusion;
+        return string.IsNullOrEmpty(run.HeadBranch) ? state : $"{run.HeadBranch} - {state}";
+    }
+
+    private static bool IsCancellable(string status)
+    {
+        return status.Equals("queued", StringComparison.OrdinalIgnoreCase)
+            || status.Equals("in_progress", StringComparison.OrdinalIgnoreCase)
+            || status.Equals("InProgress", StringComparison.OrdinalIgnoreCase)
+            || status.Equals("Queued", StringComparison.OrdinalIgnoreCase)
+            || status.Equals("requested", StringComparison.OrdinalIgnoreCase)
+            || status.Equals("waiting", StringComparison.OrdinalIgnoreCase)
+            || status.Equals("pending", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/GitHubExtension/Controls/Templates/TriggerWorkflowTemplate.json
+++ b/GitHubExtension/Controls/Templates/TriggerWorkflowTemplate.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "TextBlock",
+      "size": "Medium",
+      "weight": "Bolder",
+      "text": {{TriggerWorkflowFormTitle}},
+      "horizontalAlignment": "Center",
+      "wrap": true,
+      "style": "heading"
+    },
+    {
+      "type": "Input.Text",
+      "id": "Repository",
+      "label": {{RepositoryLabel}},
+      "placeholder": {{RepositoryPlaceholder}},
+      "isRequired": true,
+      "errorMessage": {{RepositoryErrorMessage}},
+      "value": {{RepositoryValue}}
+    },
+    {
+      "type": "Input.Text",
+      "id": "WorkflowFile",
+      "label": {{WorkflowFileLabel}},
+      "placeholder": {{WorkflowFilePlaceholder}},
+      "isRequired": true,
+      "errorMessage": {{WorkflowFileErrorMessage}}
+    },
+    {
+      "type": "Input.Text",
+      "id": "Ref",
+      "label": {{RefLabel}},
+      "placeholder": {{RefPlaceholder}},
+      "isRequired": true,
+      "errorMessage": {{RefErrorMessage}},
+      "value": {{RefValue}}
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.Submit",
+      "title": {{TriggerWorkflowActionTitle}},
+      "data": {
+        "id": "TriggerWorkflowAction"
+      }
+    }
+  ]
+}

--- a/GitHubExtension/Controls/WorkflowRun.cs
+++ b/GitHubExtension/Controls/WorkflowRun.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace GitHubExtension.Controls;
+
+public sealed class WorkflowRun : IWorkflowRun
+{
+    public long Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public string Status { get; set; } = string.Empty;
+
+    public string Conclusion { get; set; } = string.Empty;
+
+    public string HeadBranch { get; set; } = string.Empty;
+
+    public string TriggerEvent { get; set; } = string.Empty;
+
+    public long RunNumber { get; set; }
+
+    public string HtmlUrl { get; set; } = string.Empty;
+
+    public string RepositoryFullName { get; set; } = string.Empty;
+
+    public DateTimeOffset CreatedAt { get; set; }
+}

--- a/GitHubExtension/Controls/WorkflowRunsMediator.cs
+++ b/GitHubExtension/Controls/WorkflowRunsMediator.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace GitHubExtension.Controls;
+
+public class WorkflowRunsMediator
+{
+    public event EventHandler<object?>? WorkflowRunsChanged;
+
+    public WorkflowRunsMediator()
+    {
+    }
+
+    public void NotifyWorkflowRunsChanged(object? args = null)
+    {
+        WorkflowRunsChanged?.Invoke(this, args);
+    }
+}

--- a/GitHubExtension/DataManager/Data/WorkflowRunsDataManager.cs
+++ b/GitHubExtension/DataManager/Data/WorkflowRunsDataManager.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Client;
+using GitHubExtension.Controls;
+using Octokit;
+using Serilog;
+
+namespace GitHubExtension.DataManager.Data;
+
+public sealed class WorkflowRunsDataManager : IWorkflowRunsDataManager
+{
+    private const int DefaultPageSize = 30;
+
+    private static readonly Lazy<ILogger> _logger = new(() => Serilog.Log.ForContext("SourceContext", nameof(WorkflowRunsDataManager)));
+
+    private static readonly ILogger _log = _logger.Value;
+
+    private readonly GitHubClientProvider _gitHubClientProvider;
+
+    public WorkflowRunsDataManager(GitHubClientProvider gitHubClientProvider)
+    {
+        _gitHubClientProvider = gitHubClientProvider;
+    }
+
+    public async Task<IEnumerable<IWorkflowRun>> GetWorkflowRunsAsync(string ownerRepo)
+    {
+        var (owner, repo) = GitHubCreateManager.ParseOwnerRepo(ownerRepo);
+        var client = await _gitHubClientProvider.GetClientForLoggedInDeveloper(false);
+
+        var options = new ApiOptions { PageCount = 1, PageSize = DefaultPageSize, StartPage = 1 };
+        var response = await client.Actions.Workflows.Runs.List(owner, repo, new WorkflowRunsRequest(), options);
+
+        _log.Debug($"Retrieved {response.WorkflowRuns.Count} workflow runs for {owner}/{repo}.");
+
+        return response.WorkflowRuns.Select(run => ToWorkflowRun(run, $"{owner}/{repo}")).ToList();
+    }
+
+    public async Task RerunAsync(string ownerRepo, long runId)
+    {
+        var (owner, repo) = GitHubCreateManager.ParseOwnerRepo(ownerRepo);
+        var client = await _gitHubClientProvider.GetClientForLoggedInDeveloper(false);
+        await client.Actions.Workflows.Runs.Rerun(owner, repo, runId);
+        _log.Information($"Re-ran workflow run {runId} in {owner}/{repo}.");
+    }
+
+    public async Task CancelAsync(string ownerRepo, long runId)
+    {
+        var (owner, repo) = GitHubCreateManager.ParseOwnerRepo(ownerRepo);
+        var client = await _gitHubClientProvider.GetClientForLoggedInDeveloper(false);
+        await client.Actions.Workflows.Runs.Cancel(owner, repo, runId);
+        _log.Information($"Cancelled workflow run {runId} in {owner}/{repo}.");
+    }
+
+    public async Task TriggerWorkflowAsync(string ownerRepo, string workflowFileName, string gitRef)
+    {
+        var (owner, repo) = GitHubCreateManager.ParseOwnerRepo(ownerRepo);
+        var client = await _gitHubClientProvider.GetClientForLoggedInDeveloper(false);
+        await client.Actions.Workflows.CreateDispatch(owner, repo, workflowFileName, new CreateWorkflowDispatch(gitRef));
+        _log.Information($"Triggered workflow {workflowFileName} on {gitRef} in {owner}/{repo}.");
+    }
+
+    private static Controls.WorkflowRun ToWorkflowRun(Octokit.WorkflowRun run, string repositoryFullName)
+    {
+        return new Controls.WorkflowRun
+        {
+            Id = run.Id,
+            Name = run.Name ?? string.Empty,
+            Status = run.Status.StringValue ?? string.Empty,
+            Conclusion = run.Conclusion.HasValue ? (run.Conclusion.Value.StringValue ?? string.Empty) : string.Empty,
+            HeadBranch = run.HeadBranch ?? string.Empty,
+            TriggerEvent = run.Event ?? string.Empty,
+            RunNumber = run.RunNumber,
+            HtmlUrl = run.HtmlUrl ?? string.Empty,
+            RepositoryFullName = repositoryFullName,
+            CreatedAt = run.CreatedAt,
+        };
+    }
+}

--- a/GitHubExtension/DataManager/IWorkflowRunsDataManager.cs
+++ b/GitHubExtension/DataManager/IWorkflowRunsDataManager.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Controls;
+
+namespace GitHubExtension.DataManager;
+
+public interface IWorkflowRunsDataManager
+{
+    // Fetches the most recent workflow runs for the given repository. The
+    // repository may be provided as the short owner/repo form or a full URL.
+    Task<IEnumerable<IWorkflowRun>> GetWorkflowRunsAsync(string ownerRepo);
+
+    // Re-runs all jobs for a workflow run. This is a non-destructive action.
+    Task RerunAsync(string ownerRepo, long runId);
+
+    // Cancels an in-progress workflow run. This is a destructive action.
+    Task CancelAsync(string ownerRepo, long runId);
+
+    // Triggers a workflow_dispatch event for the given workflow file on the
+    // provided git reference (branch or tag).
+    Task TriggerWorkflowAsync(string ownerRepo, string workflowFileName, string gitRef);
+}

--- a/GitHubExtension/GitHubExtensionCommandsProvider.cs
+++ b/GitHubExtension/GitHubExtensionCommandsProvider.cs
@@ -28,6 +28,8 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
     private readonly AuthenticationMediator _authenticationMediator;
     private readonly NotificationsMediator _notificationsMediator;
     private readonly IGitHubCreateManager _createManager;
+    private readonly WorkflowRunsPage _workflowRunsPage;
+    private readonly IWorkflowRunsDataManager _workflowRunsDataManager;
 
     public GitHubExtensionCommandsProvider(
         SavedSearchesPage savedSearchesPage,
@@ -41,7 +43,9 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
         SavedSearchesMediator savedSearchesMediator,
         AuthenticationMediator authenticationMediator,
         NotificationsMediator notificationsMediator,
-        IGitHubCreateManager createManager)
+        IGitHubCreateManager createManager,
+        WorkflowRunsPage workflowRunsPage,
+        IWorkflowRunsDataManager workflowRunsDataManager)
     {
         _savedSearchesPage = savedSearchesPage;
         _signOutPage = signOutPage;
@@ -55,6 +59,8 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
         _authenticationMediator = authenticationMediator;
         _notificationsMediator = notificationsMediator;
         _createManager = createManager;
+        _workflowRunsPage = workflowRunsPage;
+        _workflowRunsDataManager = workflowRunsDataManager;
 
         DisplayName = _resources.GetResource("ExtensionTitle");
 
@@ -114,6 +120,8 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
             BuildCreateIssueCommandItem(),
             BuildCreatePullRequestCommandItem(),
             BuildCreateBranchCommandItem(),
+            BuildWorkflowRunsCommandItem(),
+            BuildTriggerWorkflowCommandItem(),
             new(_savedSearchesPage),
             new(_signOutPage),
         };
@@ -170,6 +178,32 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
         {
             Title = _resources.GetResource("CommandsProvider_CreateBranchCommandName"),
             Subtitle = _resources.GetResource("CommandsProvider_CreateBranchSubtitle"),
+        };
+    }
+
+    private CommandItem BuildWorkflowRunsCommandItem()
+    {
+        return new CommandItem(_workflowRunsPage)
+        {
+            Title = _resources.GetResource("CommandsProvider_WorkflowRunsCommandName"),
+            Subtitle = _resources.GetResource("CommandsProvider_WorkflowRunsSubtitle"),
+        };
+    }
+
+    private CommandItem BuildTriggerWorkflowCommandItem()
+    {
+        var page = new GitHubFormPage(
+            new TriggerWorkflowForm(_workflowRunsDataManager, _resources),
+            _resources,
+            "Forms_TriggerWorkflow_Title",
+            "\uE724",
+            "Message_TriggerWorkflow_Success",
+            "Message_TriggerWorkflow_Error");
+
+        return new CommandItem(page)
+        {
+            Title = _resources.GetResource("CommandsProvider_TriggerWorkflowCommandName"),
+            Subtitle = _resources.GetResource("CommandsProvider_TriggerWorkflowSubtitle"),
         };
     }
 

--- a/GitHubExtension/Helpers/GitHubIcon.cs
+++ b/GitHubExtension/Helpers/GitHubIcon.cs
@@ -26,6 +26,7 @@ public static class GitHubIcon
                 { "Repositories", new IconInfo("\uE8F1") },
                 { "notification", new IconInfo("\uEA8F") },
                 { "Notifications", new IconInfo("\uEA8F") },
+                { "Workflows", new IconInfo("\uE9F5") },
             };
     }
 

--- a/GitHubExtension/Helpers/TemplateHelper.cs
+++ b/GitHubExtension/Helpers/TemplateHelper.cs
@@ -18,6 +18,7 @@ public static class TemplateHelper
             "CreatePullRequest" => "Controls\\Templates\\CreatePullRequestTemplate.json",
             "CreateBranch" => "Controls\\Templates\\CreateBranchTemplate.json",
             "AddComment" => "Controls\\Templates\\AddCommentTemplate.json",
+            "TriggerWorkflow" => "Controls\\Templates\\TriggerWorkflowTemplate.json",
             _ => throw new NotImplementedException($"Template for page '{page}' is not implemented."),
         };
     }

--- a/GitHubExtension/Program.cs
+++ b/GitHubExtension/Program.cs
@@ -133,9 +133,13 @@ public class Program
         var savedSearchesMediator = new SavedSearchesMediator();
         var notificationsMediator = new NotificationsMediator();
         var mutationMediator = new MutationMediator();
+        var workflowRunsMediator = new WorkflowRunsMediator();
 
         var notificationsDataManager = new NotificationsDataManager(gitHubClientProvider);
         var notificationsPage = new NotificationsPage(notificationsDataManager, notificationsMediator, resources);
+
+        var workflowRunsDataManager = new WorkflowRunsDataManager(gitHubClientProvider);
+        var workflowRunsPage = new WorkflowRunsPage(workflowRunsDataManager, workflowRunsMediator, resources);
 
         var mutationManager = new GitHubMutationManager(gitHubClientProvider);
         var createManager = new GitHubCreateManager(gitHubClientProvider);
@@ -155,7 +159,7 @@ public class Program
         using var signInForm = new SignInForm(authenticationMediator, resources, developerIdProvider, signInCommand);
         using var signInPage = new SignInPage(signInForm, resources, signInCommand, authenticationMediator);
 
-        using var commandProvider = new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, notificationsPage, developerIdProvider, searchRepository, resources, searchPageFactory, savedSearchesMediator, authenticationMediator, notificationsMediator, createManager);
+        using var commandProvider = new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, notificationsPage, developerIdProvider, searchRepository, resources, searchPageFactory, savedSearchesMediator, authenticationMediator, notificationsMediator, createManager, workflowRunsPage, workflowRunsDataManager);
         var extensionInstance = new GitHubExtension(extensionDisposedEvent, commandProvider);
 
         // We are instantiating an extension instance once above, and returning it every time the callback in RegisterExtension below is called.

--- a/GitHubExtension/Strings/en-US/Resources.resw
+++ b/GitHubExtension/Strings/en-US/Resources.resw
@@ -705,4 +705,112 @@
     <value>Sign in to the GitHub Extension (Preview)</value>
     <comment>The title for the SignInPage</comment>
   </data>
+  <data name="CommandsProvider_WorkflowRunsCommandName" xml:space="preserve">
+    <value>Workflow runs</value>
+    <comment>Name of the top-level Workflow Runs command</comment>
+  </data>
+  <data name="CommandsProvider_WorkflowRunsSubtitle" xml:space="preserve">
+    <value>View GitHub Actions workflow runs for a repository</value>
+    <comment>Subtitle of the top-level Workflow Runs command</comment>
+  </data>
+  <data name="CommandsProvider_TriggerWorkflowCommandName" xml:space="preserve">
+    <value>Trigger workflow</value>
+    <comment>Name of the top-level Trigger Workflow command</comment>
+  </data>
+  <data name="CommandsProvider_TriggerWorkflowSubtitle" xml:space="preserve">
+    <value>Run a workflow_dispatch event for a repository</value>
+    <comment>Subtitle of the top-level Trigger Workflow command</comment>
+  </data>
+  <data name="Pages_WorkflowRuns" xml:space="preserve">
+    <value>Workflow runs</value>
+    <comment>Title of the Workflow Runs page</comment>
+  </data>
+  <data name="Pages_WorkflowRuns_Placeholder" xml:space="preserve">
+    <value>Type a repository as owner/repo</value>
+    <comment>Placeholder text shown in the Workflow Runs search box</comment>
+  </data>
+  <data name="Pages_WorkflowRuns_Prompt" xml:space="preserve">
+    <value>Type a repository as owner/repo to view its workflow runs</value>
+    <comment>Prompt shown on the Workflow Runs page before a repository is entered</comment>
+  </data>
+  <data name="Pages_WorkflowRuns_None" xml:space="preserve">
+    <value>No workflow runs found</value>
+    <comment>Message shown when a repository has no workflow runs</comment>
+  </data>
+  <data name="Pages_WorkflowRuns_UnnamedRun" xml:space="preserve">
+    <value>Workflow run</value>
+    <comment>Fallback title for a workflow run with no name</comment>
+  </data>
+  <data name="Commands_RerunWorkflow" xml:space="preserve">
+    <value>Re-run workflow</value>
+    <comment>Command name for re-running a workflow run</comment>
+  </data>
+  <data name="Commands_CancelWorkflow" xml:space="preserve">
+    <value>Cancel workflow</value>
+    <comment>Command name for cancelling a workflow run</comment>
+  </data>
+  <data name="Confirm_CancelWorkflow_Title" xml:space="preserve">
+    <value>Cancel workflow run?</value>
+    <comment>Confirmation dialog title for cancelling a workflow run</comment>
+  </data>
+  <data name="Confirm_CancelWorkflow_Description" xml:space="preserve">
+    <value>This will stop the in-progress workflow run.</value>
+    <comment>Confirmation dialog description for cancelling a workflow run</comment>
+  </data>
+  <data name="Message_RerunWorkflow_Success" xml:space="preserve">
+    <value>Workflow run restarted</value>
+    <comment>Success toast shown after re-running a workflow run</comment>
+  </data>
+  <data name="Message_RerunWorkflow_Error" xml:space="preserve">
+    <value>Failed to re-run the workflow</value>
+    <comment>Error toast shown when re-running a workflow run fails</comment>
+  </data>
+  <data name="Message_CancelWorkflow_Success" xml:space="preserve">
+    <value>Workflow run cancelled</value>
+    <comment>Success toast shown after cancelling a workflow run</comment>
+  </data>
+  <data name="Message_CancelWorkflow_Error" xml:space="preserve">
+    <value>Failed to cancel the workflow</value>
+    <comment>Error toast shown when cancelling a workflow run fails</comment>
+  </data>
+  <data name="Message_TriggerWorkflow_Success" xml:space="preserve">
+    <value>Workflow triggered</value>
+    <comment>Success toast shown after triggering a workflow</comment>
+  </data>
+  <data name="Message_TriggerWorkflow_Error" xml:space="preserve">
+    <value>Failed to trigger the workflow</value>
+    <comment>Error toast shown when triggering a workflow fails</comment>
+  </data>
+  <data name="Forms_TriggerWorkflow_Title" xml:space="preserve">
+    <value>Trigger workflow</value>
+    <comment>Title of the Trigger Workflow form</comment>
+  </data>
+  <data name="Forms_TriggerWorkflow_WorkflowFileLabel" xml:space="preserve">
+    <value>Workflow file</value>
+    <comment>Label for the workflow file input</comment>
+  </data>
+  <data name="Forms_TriggerWorkflow_WorkflowFilePlaceholder" xml:space="preserve">
+    <value>e.g. build.yml</value>
+    <comment>Placeholder for the workflow file input</comment>
+  </data>
+  <data name="Forms_TriggerWorkflow_WorkflowFileError" xml:space="preserve">
+    <value>Workflow file is required</value>
+    <comment>Validation error for the workflow file input</comment>
+  </data>
+  <data name="Forms_TriggerWorkflow_RefLabel" xml:space="preserve">
+    <value>Branch or tag</value>
+    <comment>Label for the git ref input</comment>
+  </data>
+  <data name="Forms_TriggerWorkflow_RefPlaceholder" xml:space="preserve">
+    <value>e.g. main</value>
+    <comment>Placeholder for the git ref input</comment>
+  </data>
+  <data name="Forms_TriggerWorkflow_RefError" xml:space="preserve">
+    <value>A branch or tag is required</value>
+    <comment>Validation error for the git ref input</comment>
+  </data>
+  <data name="Forms_TriggerWorkflow_Action" xml:space="preserve">
+    <value>Trigger workflow</value>
+    <comment>Submit button title for the Trigger Workflow form</comment>
+  </data>
 </root>


### PR DESCRIPTION
Part of the CmdPal GitHub extension parity roadmap (stacked on M4, PR #291).

## Summary
Adds GitHub Actions workflow-run support: a repository-scoped runs list plus re-run, cancel, and trigger actions.

### Data layer
- \IWorkflowRun\ / \WorkflowRun\ data type.
- \IWorkflowRunsDataManager\ / \WorkflowRunsDataManager\ over the Octokit Actions API: list recent runs, re-run, cancel, and \workflow_dispatch\ trigger. Reuses \GitHubCreateManager.ParseOwnerRepo\ so both \owner/repo\ and full URLs work.

### Command surface
- **Workflow Runs** top-level command opens a \DynamicListPage\; the user types \owner/repo\ in the search box and the page lists the most recent runs. Each run offers: re-run (non-destructive), cancel (destructive, confirmed + critical, only shown for in-progress/queued runs), open in browser, and copy URL.
- **Trigger Workflow** top-level command: a \FormContent\ form (repository, workflow file, ref) that fires a \workflow_dispatch\ event.

### Infrastructure reuse
- \WorkflowRunsMediator\ + \WorkflowRunActionCommand\ mirror the notifications/mutation event-driven refresh pattern. Cancel wraps the action in the existing \ConfirmedCommand\.
- Added a URL-based \LinkCommand\ overload, a Workflows icon, and the \TriggerWorkflow\ template case.

## Design note
Workflow runs are inherently repository-scoped, so the page takes the repository from the search box rather than trying to aggregate runs across all repositories. This keeps a single, predictable API call per view.

## Tests
- \WorkflowRunsTests\: Trigger Workflow form renders valid adaptive-card JSON; page shows a prompt when empty, a none-message when a repo has no runs, renders run items, and shows the cancel command only for in-progress runs.
- Full suite: 192/192 passing. Build clean (x64 Debug).

## Localization
Added top-level command names/subtitles, page prompts, run action titles, confirmation dialog text, success/error toasts, and the Trigger Workflow form strings to \Resources.resw\.