### PR TITLE
M6: Discussions & Projects (GraphQL) + Auto-merge

### DIFF
--- a/GitHubExtension.Test/Controls/DiscussionsAndProjectsTests.cs
+++ b/GitHubExtension.Test/Controls/DiscussionsAndProjectsTests.cs
@@ -1,0 +1,187 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Nodes;
+using GitHubExtension.Client;
+using GitHubExtension.Controls;
+using GitHubExtension.Controls.Pages;
+using GitHubExtension.DataManager;
+using GitHubExtension.DataManager.Data;
+using GitHubExtension.Helpers;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Moq;
+
+namespace GitHubExtension.Test.Controls;
+
+[TestClass]
+public class DiscussionsAndProjectsTests
+{
+    private static Mock<IResources> CreateResources()
+    {
+        var resources = new Mock<IResources>();
+        resources.Setup(x => x.GetResource(It.IsAny<string>(), null)).Returns<string, object>((key, _) => key);
+        return resources;
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void ResolveGraphQLEndpoint_GitHubCom_ReturnsApiGraphQL()
+    {
+        var endpoint = GitHubGraphQLClient.ResolveGraphQLEndpoint(new Uri("https://api.github.com/"));
+        Assert.AreEqual("https://api.github.com/graphql", endpoint.ToString());
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void ResolveGraphQLEndpoint_EnterpriseServer_ReturnsHostApiGraphQL()
+    {
+        var endpoint = GitHubGraphQLClient.ResolveGraphQLEndpoint(new Uri("https://ghe.example.com/api/v3/"));
+        Assert.AreEqual("https://ghe.example.com/api/graphql", endpoint.ToString());
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public async Task DiscussionsDataManager_MapsSearchNodes()
+    {
+        var data = JsonNode.Parse(@"{
+          ""search"": {
+            ""nodes"": [
+              { ""title"": ""First"", ""url"": ""https://github.com/o/r/discussions/1"", ""number"": 1, ""updatedAt"": ""2024-01-01T00:00:00Z"", ""repository"": { ""nameWithOwner"": ""o/r"" }, ""author"": { ""login"": ""octocat"" } },
+              { ""title"": ""Second"", ""url"": ""https://github.com/o/r/discussions/2"", ""number"": 2, ""updatedAt"": ""2024-01-02T00:00:00Z"", ""repository"": { ""nameWithOwner"": ""o/r"" }, ""author"": { ""login"": ""hubber"" } }
+            ]
+          }
+        }");
+
+        var client = new Mock<IGitHubGraphQLClient>();
+        client.Setup(x => x.QueryAsync(It.IsAny<string>(), It.IsAny<object?>())).ReturnsAsync(data);
+
+        var manager = new DiscussionsDataManager(client.Object);
+        var discussions = (await manager.SearchDiscussionsAsync("author:@me")).ToList();
+
+        Assert.AreEqual(2, discussions.Count);
+        Assert.AreEqual("First", discussions[0].Title);
+        Assert.AreEqual("o/r", discussions[0].RepositoryFullName);
+        Assert.AreEqual("octocat", discussions[0].Author);
+        Assert.AreEqual(2, discussions[1].Number);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public async Task DiscussionsDataManager_NoNodes_ReturnsEmpty()
+    {
+        var client = new Mock<IGitHubGraphQLClient>();
+        client.Setup(x => x.QueryAsync(It.IsAny<string>(), It.IsAny<object?>())).ReturnsAsync(JsonNode.Parse("{}"));
+
+        var manager = new DiscussionsDataManager(client.Object);
+        var discussions = await manager.SearchDiscussionsAsync("author:@me");
+
+        Assert.AreEqual(0, discussions.Count());
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public async Task ProjectsDataManager_MapsViewerProjects()
+    {
+        var data = JsonNode.Parse(@"{
+          ""viewer"": {
+            ""projectsV2"": {
+              ""nodes"": [
+                { ""title"": ""Roadmap"", ""url"": ""https://github.com/users/o/projects/1"", ""number"": 1, ""closed"": false },
+                { ""title"": ""Archive"", ""url"": ""https://github.com/users/o/projects/2"", ""number"": 2, ""closed"": true }
+              ]
+            }
+          }
+        }");
+
+        var client = new Mock<IGitHubGraphQLClient>();
+        client.Setup(x => x.QueryAsync(It.IsAny<string>(), It.IsAny<object?>())).ReturnsAsync(data);
+
+        var manager = new ProjectsDataManager(client.Object);
+        var projects = (await manager.GetMyProjectsAsync()).ToList();
+
+        Assert.AreEqual(2, projects.Count);
+        Assert.AreEqual("Roadmap", projects[0].Title);
+        Assert.IsFalse(projects[0].Closed);
+        Assert.IsTrue(projects[1].Closed);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public async Task AutoMergeManager_Enable_ResolvesIdThenMutates()
+    {
+        var idData = JsonNode.Parse(@"{ ""repository"": { ""pullRequest"": { ""id"": ""PR_kabc123"" } } }");
+
+        var client = new Mock<IGitHubGraphQLClient>();
+        var capturedIds = new List<string?>();
+        client.Setup(x => x.QueryAsync(It.Is<string>(q => q.Contains("pullRequest(number")), It.IsAny<object?>()))
+            .ReturnsAsync(idData);
+        client.Setup(x => x.QueryAsync(It.Is<string>(q => q.Contains("enablePullRequestAutoMerge")), It.IsAny<object?>()))
+            .Callback<string, object?>((_, vars) =>
+            {
+                var dict = (IDictionary<string, object?>)vars!;
+                capturedIds.Add(dict["id"]?.ToString());
+            })
+            .ReturnsAsync((JsonNode?)null);
+
+        var pr = new Mock<IPullRequest>();
+        pr.Setup(x => x.HtmlUrl).Returns("https://github.com/owner/repo/pull/7");
+        pr.Setup(x => x.Number).Returns(7);
+
+        var manager = new GitHubAutoMergeManager(client.Object);
+        await manager.EnableAutoMergeAsync(pr.Object);
+
+        var expectedIds = new[] { "PR_kabc123" };
+        CollectionAssert.AreEqual(expectedIds, capturedIds);
+        client.Verify(x => x.QueryAsync(It.Is<string>(q => q.Contains("enablePullRequestAutoMerge")), It.IsAny<object?>()), Times.Once);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DiscussionsPage_EmptyQuery_ShowsPrompt()
+    {
+        var manager = new Mock<IDiscussionsDataManager>();
+        var page = new DiscussionsPage(manager.Object, CreateResources().Object, "Search discussions", string.Empty);
+
+        var items = page.GetItems();
+
+        Assert.AreEqual(1, items.Length);
+        Assert.AreEqual("Pages_Discussions_Prompt", items[0].Title);
+        manager.Verify(x => x.SearchDiscussionsAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void DiscussionsPage_MyDiscussions_UsesBaseQuery()
+    {
+        var manager = new Mock<IDiscussionsDataManager>();
+        manager.Setup(x => x.SearchDiscussionsAsync(It.IsAny<string>()))
+            .ReturnsAsync(new[] { new Discussion { Title = "D", HtmlUrl = "https://github.com/o/r/discussions/1" } });
+
+        var page = new DiscussionsPage(manager.Object, CreateResources().Object, "My discussions", "author:@me");
+
+        var items = page.GetItems();
+
+        Assert.AreEqual(1, items.Length);
+        manager.Verify(x => x.SearchDiscussionsAsync("author:@me"), Times.Once);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void ProjectsPage_WithProjects_ReturnsItems()
+    {
+        var manager = new Mock<IProjectsDataManager>();
+        manager.Setup(x => x.GetMyProjectsAsync())
+            .ReturnsAsync(new[]
+            {
+                new Project { Title = "A", HtmlUrl = "https://github.com/users/o/projects/1", Closed = false },
+                new Project { Title = "B", HtmlUrl = "https://github.com/users/o/projects/2", Closed = true },
+            });
+
+        var page = new ProjectsPage(manager.Object, CreateResources().Object);
+
+        var items = page.GetItems();
+
+        Assert.AreEqual(2, items.Length);
+    }
+}

--- a/GitHubExtension.Test/Controls/MutationCommandsFactoryTests.cs
+++ b/GitHubExtension.Test/Controls/MutationCommandsFactoryTests.cs
@@ -17,10 +17,11 @@ public class MutationCommandsFactoryTests
     {
         var manager = new Mock<IGitHubMutationManager>();
         var createManager = new Mock<IGitHubCreateManager>();
+        var autoMergeManager = new Mock<IGitHubAutoMergeManager>();
         var mediator = new MutationMediator();
         var resources = new Mock<IResources>();
         resources.Setup(x => x.GetResource(It.IsAny<string>(), null)).Returns<string, object>((key, _) => key);
-        var factory = new MutationCommandsFactory(manager.Object, createManager.Object, mediator, resources.Object);
+        var factory = new MutationCommandsFactory(manager.Object, createManager.Object, autoMergeManager.Object, mediator, resources.Object);
         return (factory, manager, mediator);
     }
 
@@ -76,11 +77,15 @@ public class MutationCommandsFactoryTests
         var (factory, _, _) = CreateFactory();
         var commands = factory.GetPullRequestCommands(CreatePullRequest("Open").Object).ToList();
 
-        Assert.AreEqual(3, commands.Count);
+        Assert.AreEqual(5, commands.Count);
         Assert.AreEqual("Commands_MergePullRequest", commands[0].Command!.Name);
         Assert.AreEqual("Commands_ClosePullRequest", commands[1].Command!.Name);
+        Assert.AreEqual("Commands_EnableAutoMerge", commands[2].Command!.Name);
+        Assert.AreEqual("Commands_DisableAutoMerge", commands[3].Command!.Name);
         Assert.IsTrue(commands[0].IsCritical);
         Assert.IsTrue(commands[1].IsCritical);
+        Assert.IsFalse(commands[2].IsCritical);
+        Assert.IsFalse(commands[3].IsCritical);
     }
 
     [TestMethod]

--- a/GitHubExtension.Test/Controls/SearchPagesTests.cs
+++ b/GitHubExtension.Test/Controls/SearchPagesTests.cs
@@ -21,8 +21,9 @@ public class SearchPagesTests
     {
         var mutationManager = new Mock<IGitHubMutationManager>();
         var createManager = new Mock<IGitHubCreateManager>();
+        var autoMergeManager = new Mock<IGitHubAutoMergeManager>();
         var mediator = new MutationMediator();
-        var factory = new MutationCommandsFactory(mutationManager.Object, createManager.Object, mediator, resources.Object);
+        var factory = new MutationCommandsFactory(mutationManager.Object, createManager.Object, autoMergeManager.Object, mediator, resources.Object);
         return (factory, mediator);
     }
 

--- a/GitHubExtension.Test/Controls/TopLevelSearchesTest.cs
+++ b/GitHubExtension.Test/Controls/TopLevelSearchesTest.cs
@@ -114,8 +114,9 @@ public class TopLevelSearchesTest
             var mockCacheDataManager = new Mock<ICacheDataManager>().Object;
             var mutationManager = new Mock<IGitHubMutationManager>().Object;
             var createManager = new Mock<IGitHubCreateManager>().Object;
+            var autoMergeManager = new Mock<IGitHubAutoMergeManager>().Object;
             var mutationMediator = new MutationMediator();
-            var mutationCommandsFactory = new MutationCommandsFactory(mutationManager, createManager, mutationMediator, resources);
+            var mutationCommandsFactory = new MutationCommandsFactory(mutationManager, createManager, autoMergeManager, mutationMediator, resources);
             var searchPageFactory = new SearchPageFactory(mockCacheDataManager, persistentDataManager, resources, mediator, mutationCommandsFactory, mutationMediator);
 
             var addSearchForm = new SaveSearchForm(persistentDataManager, resources, mediator);

--- a/GitHubExtension.Test/Helpers/TestSetupHelpers.cs
+++ b/GitHubExtension.Test/Helpers/TestSetupHelpers.cs
@@ -179,6 +179,11 @@ public partial class TestHelpers
         var workflowRunsMediator = new WorkflowRunsMediator();
         var mockWorkflowRunsDataManager = new Mock<IWorkflowRunsDataManager>();
         var workflowRunsPage = new WorkflowRunsPage(mockWorkflowRunsDataManager.Object, workflowRunsMediator, mockResources);
-        return new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, notificationsPage, mockDeveloperIdProvider, persistentDataManager, mockResources, searchPageFactory, savedSearchesMediator, mockAuthenticationMediator, notificationsMediator, mockCreateManager, workflowRunsPage, mockWorkflowRunsDataManager.Object);
+        var mockDiscussionsDataManager = new Mock<IDiscussionsDataManager>();
+        var myDiscussionsPage = new DiscussionsPage(mockDiscussionsDataManager.Object, mockResources, "My discussions", "author:@me");
+        var searchDiscussionsPage = new DiscussionsPage(mockDiscussionsDataManager.Object, mockResources, "Search discussions", string.Empty);
+        var mockProjectsDataManager = new Mock<IProjectsDataManager>();
+        var projectsPage = new ProjectsPage(mockProjectsDataManager.Object, mockResources);
+        return new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, notificationsPage, mockDeveloperIdProvider, persistentDataManager, mockResources, searchPageFactory, savedSearchesMediator, mockAuthenticationMediator, notificationsMediator, mockCreateManager, workflowRunsPage, mockWorkflowRunsDataManager.Object, myDiscussionsPage, searchDiscussionsPage, projectsPage);
     }
 }

--- a/GitHubExtension/Client/GitHubGraphQLClient.cs
+++ b/GitHubExtension/Client/GitHubGraphQLClient.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Serilog;
+
+namespace GitHubExtension.Client;
+
+// Sends GraphQL queries and mutations to GitHub using the logged-in developer's
+// OAuth token. The GraphQL endpoint is derived from the REST client's base
+// address so the same code path works for github.com and (later) GitHub
+// Enterprise Server.
+public sealed class GitHubGraphQLClient : IGitHubGraphQLClient
+{
+    private static readonly Lazy<ILogger> _logger = new(() => Serilog.Log.ForContext("SourceContext", nameof(GitHubGraphQLClient)));
+
+    private static readonly ILogger _log = _logger.Value;
+
+    private static readonly HttpClient _httpClient = new();
+
+    private readonly GitHubClientProvider _gitHubClientProvider;
+
+    public GitHubGraphQLClient(GitHubClientProvider gitHubClientProvider)
+    {
+        _gitHubClientProvider = gitHubClientProvider;
+    }
+
+    public async Task<JsonNode?> QueryAsync(string query, object? variables = null)
+    {
+        var client = await _gitHubClientProvider.GetClientForLoggedInDeveloper(false);
+        var token = client.Connection.Credentials?.Password
+            ?? throw new InvalidOperationException("No authenticated GitHub token is available for GraphQL.");
+
+        var endpoint = ResolveGraphQLEndpoint(client.Connection.BaseAddress);
+
+        var payload = new Dictionary<string, object?>
+        {
+            ["query"] = query,
+        };
+
+        if (variables != null)
+        {
+            payload["variables"] = variables;
+        }
+
+        var body = JsonSerializer.Serialize(payload);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        request.Headers.UserAgent.Add(new ProductInfoHeaderValue(Constants.CMDPAL_APPLICATION_NAME, "1.0"));
+
+        using var response = await _httpClient.SendAsync(request);
+        var content = await response.Content.ReadAsStringAsync();
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _log.Error($"GraphQL request failed with status {(int)response.StatusCode}: {content}");
+            throw new HttpRequestException($"GraphQL request failed with status {(int)response.StatusCode}.");
+        }
+
+        var root = JsonNode.Parse(content);
+        var errors = root?["errors"];
+        if (errors is JsonArray errorArray && errorArray.Count > 0)
+        {
+            var message = errorArray[0]?["message"]?.ToString() ?? "Unknown GraphQL error.";
+            _log.Error($"GraphQL response returned errors: {content}");
+            throw new InvalidOperationException(message);
+        }
+
+        return root?["data"];
+    }
+
+    internal static Uri ResolveGraphQLEndpoint(Uri baseAddress)
+    {
+        var host = baseAddress.Host;
+
+        // github.com REST lives at api.github.com; GraphQL is api.github.com/graphql.
+        if (host.Equals("api.github.com", StringComparison.OrdinalIgnoreCase)
+            || host.Equals("github.com", StringComparison.OrdinalIgnoreCase))
+        {
+            return new Uri("https://api.github.com/graphql");
+        }
+
+        // GitHub Enterprise Server: https://HOST/api/graphql.
+        return new Uri($"{baseAddress.Scheme}://{baseAddress.Authority}/api/graphql");
+    }
+}

--- a/GitHubExtension/Client/IGitHubGraphQLClient.cs
+++ b/GitHubExtension/Client/IGitHubGraphQLClient.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Nodes;
+
+namespace GitHubExtension.Client;
+
+// Minimal GraphQL access for capabilities not covered by the Octokit REST
+// client (Discussions, Projects v2, and auto-merge mutations). Returns the
+// "data" node of the GraphQL response.
+public interface IGitHubGraphQLClient
+{
+    Task<JsonNode?> QueryAsync(string query, object? variables = null);
+}

--- a/GitHubExtension/Controls/Commands/MutationCommandsFactory.cs
+++ b/GitHubExtension/Controls/Commands/MutationCommandsFactory.cs
@@ -16,17 +16,20 @@ public sealed class MutationCommandsFactory
 {
     private readonly IGitHubMutationManager _mutationManager;
     private readonly IGitHubCreateManager _createManager;
+    private readonly IGitHubAutoMergeManager _autoMergeManager;
     private readonly MutationMediator _mediator;
     private readonly IResources _resources;
 
     private static readonly IconInfo CloseIcon = new("\uE711");
     private static readonly IconInfo ReopenIcon = new("\uE72C");
     private static readonly IconInfo MergeIcon = new("\uE8FB");
+    private static readonly IconInfo AutoMergeIcon = new("\uE945");
 
-    public MutationCommandsFactory(IGitHubMutationManager mutationManager, IGitHubCreateManager createManager, MutationMediator mediator, IResources resources)
+    public MutationCommandsFactory(IGitHubMutationManager mutationManager, IGitHubCreateManager createManager, IGitHubAutoMergeManager autoMergeManager, MutationMediator mediator, IResources resources)
     {
         _mutationManager = mutationManager;
         _createManager = createManager;
+        _autoMergeManager = autoMergeManager;
         _mediator = mediator;
         _resources = resources;
     }
@@ -126,6 +129,26 @@ public sealed class MutationCommandsFactory
                 _resources.GetResource("Confirm_ClosePullRequest_Description"));
 
             items.Add(new CommandContextItem(confirmedClose) { IsCritical = true });
+
+            var enableAutoMerge = new GitHubMutationCommand(
+                _resources.GetResource("Commands_EnableAutoMerge"),
+                AutoMergeIcon,
+                () => _autoMergeManager.EnableAutoMergeAsync(pullRequest),
+                _resources.GetResource("Message_EnableAutoMerge_Success"),
+                _resources.GetResource("Message_EnableAutoMerge_Error"),
+                _mediator);
+
+            items.Add(new CommandContextItem(enableAutoMerge));
+
+            var disableAutoMerge = new GitHubMutationCommand(
+                _resources.GetResource("Commands_DisableAutoMerge"),
+                AutoMergeIcon,
+                () => _autoMergeManager.DisableAutoMergeAsync(pullRequest),
+                _resources.GetResource("Message_DisableAutoMerge_Success"),
+                _resources.GetResource("Message_DisableAutoMerge_Error"),
+                _mediator);
+
+            items.Add(new CommandContextItem(disableAutoMerge));
         }
         else
         {

--- a/GitHubExtension/Controls/Discussion.cs
+++ b/GitHubExtension/Controls/Discussion.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace GitHubExtension.Controls;
+
+public sealed class Discussion : IDiscussion
+{
+    public string Title { get; set; } = string.Empty;
+
+    public long Number { get; set; }
+
+    public string HtmlUrl { get; set; } = string.Empty;
+
+    public string RepositoryFullName { get; set; } = string.Empty;
+
+    public string Author { get; set; } = string.Empty;
+
+    public DateTimeOffset UpdatedAt { get; set; }
+}

--- a/GitHubExtension/Controls/IDiscussion.cs
+++ b/GitHubExtension/Controls/IDiscussion.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace GitHubExtension.Controls;
+
+public interface IDiscussion
+{
+    string Title { get; }
+
+    long Number { get; }
+
+    string HtmlUrl { get; }
+
+    string RepositoryFullName { get; }
+
+    string Author { get; }
+
+    DateTimeOffset UpdatedAt { get; }
+}

--- a/GitHubExtension/Controls/IProject.cs
+++ b/GitHubExtension/Controls/IProject.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace GitHubExtension.Controls;
+
+public interface IProject
+{
+    string Title { get; }
+
+    long Number { get; }
+
+    string HtmlUrl { get; }
+
+    bool Closed { get; }
+}

--- a/GitHubExtension/Controls/Pages/DiscussionsPage.cs
+++ b/GitHubExtension/Controls/Pages/DiscussionsPage.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Controls.Commands;
+using GitHubExtension.DataManager;
+using GitHubExtension.Helpers;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Serilog;
+
+namespace GitHubExtension.Controls.Pages;
+
+// Lists GitHub discussions matching a search query. The user's typed text is
+// combined with an optional base query (for example "author:@me" for a "My
+// Discussions" command). When there is nothing to search, a prompt is shown.
+public sealed partial class DiscussionsPage : DynamicListPage
+{
+    private readonly IDiscussionsDataManager _dataManager;
+    private readonly IResources _resources;
+    private readonly string _baseQuery;
+    private readonly ILogger _log;
+
+    public DiscussionsPage(IDiscussionsDataManager dataManager, IResources resources, string name, string baseQuery = "")
+    {
+        _dataManager = dataManager;
+        _resources = resources;
+        _baseQuery = baseQuery;
+        _log = Log.ForContext("SourceContext", $"Pages/{nameof(DiscussionsPage)}");
+
+        Name = name;
+        Icon = GitHubIcon.IconDictionary["Discussions"];
+        PlaceholderText = resources.GetResource("Pages_Discussions_Placeholder");
+    }
+
+    public override void UpdateSearchText(string oldSearch, string newSearch)
+    {
+        RaiseItemsChanged(0);
+    }
+
+    public override IListItem[] GetItems() => DoGetItems(SearchText).GetAwaiter().GetResult();
+
+    private string BuildQuery(string searchText)
+    {
+        var parts = new[] { _baseQuery, (searchText ?? string.Empty).Trim() }
+            .Where(part => !string.IsNullOrWhiteSpace(part));
+        return string.Join(" ", parts).Trim();
+    }
+
+    private async Task<IListItem[]> DoGetItems(string query)
+    {
+        var effectiveQuery = BuildQuery(query);
+
+        if (string.IsNullOrEmpty(effectiveQuery))
+        {
+            return new IListItem[]
+            {
+                new ListItem(new NoOpCommand())
+                {
+                    Title = _resources.GetResource("Pages_Discussions_Prompt"),
+                    Icon = GitHubIcon.IconDictionary["Discussions"],
+                },
+            };
+        }
+
+        try
+        {
+            var discussions = (await _dataManager.SearchDiscussionsAsync(effectiveQuery)).ToList();
+
+            if (discussions.Count == 0)
+            {
+                return new IListItem[]
+                {
+                    new ListItem(new NoOpCommand())
+                    {
+                        Title = _resources.GetResource("Pages_Discussions_None"),
+                        Icon = GitHubIcon.IconDictionary["Discussions"],
+                    },
+                };
+            }
+
+            return discussions.Select(GetListItem).ToArray();
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to load discussions.");
+            return new IListItem[]
+            {
+                new ListItem(new NoOpCommand())
+                {
+                    Title = _resources.GetResource("Pages_Error_Title"),
+                    Details = new Details()
+                    {
+                        Title = ex.Message,
+                        Body = string.IsNullOrEmpty(ex.StackTrace) ? "There is no stack trace for the error." : ex.StackTrace,
+                    },
+                },
+            };
+        }
+    }
+
+    private ListItem GetListItem(IDiscussion discussion)
+    {
+        return new ListItem(new LinkCommand(discussion.HtmlUrl, _resources))
+        {
+            Title = discussion.Title,
+            Subtitle = discussion.RepositoryFullName,
+            Icon = GitHubIcon.IconDictionary["Discussions"],
+            MoreCommands = new CommandContextItem[]
+            {
+                new(new CopyCommand(discussion.HtmlUrl, _resources.GetResource("Commands_CopyURL"), _resources)),
+            },
+        };
+    }
+}

--- a/GitHubExtension/Controls/Pages/ProjectsPage.cs
+++ b/GitHubExtension/Controls/Pages/ProjectsPage.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Controls.Commands;
+using GitHubExtension.DataManager;
+using GitHubExtension.Helpers;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Serilog;
+
+namespace GitHubExtension.Controls.Pages;
+
+// Lists the signed-in user's Projects (v2). Open a project in the browser or
+// copy its URL.
+public sealed partial class ProjectsPage : ListPage
+{
+    private readonly IProjectsDataManager _dataManager;
+    private readonly IResources _resources;
+    private readonly ILogger _log;
+
+    public ProjectsPage(IProjectsDataManager dataManager, IResources resources)
+    {
+        _dataManager = dataManager;
+        _resources = resources;
+        _log = Log.ForContext("SourceContext", $"Pages/{nameof(ProjectsPage)}");
+
+        Name = resources.GetResource("Pages_Projects");
+        Icon = GitHubIcon.IconDictionary["Projects"];
+    }
+
+    public override IListItem[] GetItems() => DoGetItems().GetAwaiter().GetResult();
+
+    private async Task<IListItem[]> DoGetItems()
+    {
+        try
+        {
+            var projects = (await _dataManager.GetMyProjectsAsync()).ToList();
+
+            if (projects.Count == 0)
+            {
+                return new IListItem[]
+                {
+                    new ListItem(new NoOpCommand())
+                    {
+                        Title = _resources.GetResource("Pages_Projects_None"),
+                        Icon = GitHubIcon.IconDictionary["Projects"],
+                    },
+                };
+            }
+
+            return projects.Select(GetListItem).ToArray();
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to load projects.");
+            return new IListItem[]
+            {
+                new ListItem(new NoOpCommand())
+                {
+                    Title = _resources.GetResource("Pages_Error_Title"),
+                    Details = new Details()
+                    {
+                        Title = ex.Message,
+                        Body = string.IsNullOrEmpty(ex.StackTrace) ? "There is no stack trace for the error." : ex.StackTrace,
+                    },
+                },
+            };
+        }
+    }
+
+    private ListItem GetListItem(IProject project)
+    {
+        var stateKey = project.Closed ? "Pages_Projects_Closed" : "Pages_Projects_Open";
+
+        return new ListItem(new LinkCommand(project.HtmlUrl, _resources))
+        {
+            Title = project.Title,
+            Subtitle = _resources.GetResource(stateKey),
+            Icon = GitHubIcon.IconDictionary["Projects"],
+            MoreCommands = new CommandContextItem[]
+            {
+                new(new CopyCommand(project.HtmlUrl, _resources.GetResource("Commands_CopyURL"), _resources)),
+            },
+        };
+    }
+}

--- a/GitHubExtension/Controls/Project.cs
+++ b/GitHubExtension/Controls/Project.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace GitHubExtension.Controls;
+
+public sealed class Project : IProject
+{
+    public string Title { get; set; } = string.Empty;
+
+    public long Number { get; set; }
+
+    public string HtmlUrl { get; set; } = string.Empty;
+
+    public bool Closed { get; set; }
+}

--- a/GitHubExtension/DataManager/Data/DiscussionsDataManager.cs
+++ b/GitHubExtension/DataManager/Data/DiscussionsDataManager.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Text.Json.Nodes;
+using GitHubExtension.Client;
+using GitHubExtension.Controls;
+using Serilog;
+
+namespace GitHubExtension.DataManager.Data;
+
+public sealed class DiscussionsDataManager : IDiscussionsDataManager
+{
+    private const int DefaultPageSize = 30;
+
+    private const string SearchQuery = @"
+query($q: String!, $first: Int!) {
+  search(query: $q, type: DISCUSSION, first: $first) {
+    nodes {
+      ... on Discussion {
+        title
+        url
+        number
+        updatedAt
+        repository { nameWithOwner }
+        author { login }
+      }
+    }
+  }
+}";
+
+    private static readonly Lazy<ILogger> _logger = new(() => Serilog.Log.ForContext("SourceContext", nameof(DiscussionsDataManager)));
+
+    private static readonly ILogger _log = _logger.Value;
+
+    private readonly IGitHubGraphQLClient _graphQLClient;
+
+    public DiscussionsDataManager(IGitHubGraphQLClient graphQLClient)
+    {
+        _graphQLClient = graphQLClient;
+    }
+
+    public async Task<IEnumerable<IDiscussion>> SearchDiscussionsAsync(string query)
+    {
+        var variables = new Dictionary<string, object?>
+        {
+            ["q"] = query,
+            ["first"] = DefaultPageSize,
+        };
+
+        var data = await _graphQLClient.QueryAsync(SearchQuery, variables);
+        var nodes = data?["search"]?["nodes"] as JsonArray;
+
+        if (nodes == null)
+        {
+            _log.Debug("Discussion search returned no nodes.");
+            return Array.Empty<IDiscussion>();
+        }
+
+        var discussions = new List<IDiscussion>();
+        foreach (var node in nodes)
+        {
+            if (node == null)
+            {
+                continue;
+            }
+
+            discussions.Add(ToDiscussion(node));
+        }
+
+        _log.Debug($"Discussion search returned {discussions.Count} discussions.");
+        return discussions;
+    }
+
+    private static Discussion ToDiscussion(JsonNode node)
+    {
+        return new Discussion
+        {
+            Title = node["title"]?.ToString() ?? string.Empty,
+            HtmlUrl = node["url"]?.ToString() ?? string.Empty,
+            Number = ParseLong(node["number"]),
+            RepositoryFullName = node["repository"]?["nameWithOwner"]?.ToString() ?? string.Empty,
+            Author = node["author"]?["login"]?.ToString() ?? string.Empty,
+            UpdatedAt = ParseDate(node["updatedAt"]?.ToString()),
+        };
+    }
+
+    private static long ParseLong(JsonNode? node)
+    {
+        if (node != null && long.TryParse(node.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+        {
+            return value;
+        }
+
+        return 0;
+    }
+
+    private static DateTimeOffset ParseDate(string? value)
+    {
+        if (!string.IsNullOrEmpty(value) &&
+            DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsed))
+        {
+            return parsed;
+        }
+
+        return DateTimeOffset.MinValue;
+    }
+}

--- a/GitHubExtension/DataManager/Data/GitHubAutoMergeManager.cs
+++ b/GitHubExtension/DataManager/Data/GitHubAutoMergeManager.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Client;
+using GitHubExtension.Controls;
+using Serilog;
+
+namespace GitHubExtension.DataManager.Data;
+
+// Enables and disables pull-request auto-merge. Auto-merge is only available
+// through the GraphQL API, so this manager resolves the pull request's global
+// node id and then issues the corresponding GraphQL mutation.
+public sealed class GitHubAutoMergeManager : IGitHubAutoMergeManager
+{
+    private const string PullRequestIdQuery = @"
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      id
+    }
+  }
+}";
+
+    private const string EnableAutoMergeMutation = @"
+mutation($id: ID!) {
+  enablePullRequestAutoMerge(input: {pullRequestId: $id}) {
+    clientMutationId
+  }
+}";
+
+    private const string DisableAutoMergeMutation = @"
+mutation($id: ID!) {
+  disablePullRequestAutoMerge(input: {pullRequestId: $id}) {
+    clientMutationId
+  }
+}";
+
+    private static readonly Lazy<ILogger> _logger = new(() => Serilog.Log.ForContext("SourceContext", nameof(GitHubAutoMergeManager)));
+
+    private static readonly ILogger _log = _logger.Value;
+
+    private readonly IGitHubGraphQLClient _graphQLClient;
+
+    public GitHubAutoMergeManager(IGitHubGraphQLClient graphQLClient)
+    {
+        _graphQLClient = graphQLClient;
+    }
+
+    public async Task EnableAutoMergeAsync(IPullRequest pullRequest)
+    {
+        var id = await GetPullRequestIdAsync(pullRequest);
+        await _graphQLClient.QueryAsync(EnableAutoMergeMutation, new Dictionary<string, object?> { ["id"] = id });
+        _log.Information($"Enabled auto-merge for {pullRequest.HtmlUrl}.");
+    }
+
+    public async Task DisableAutoMergeAsync(IPullRequest pullRequest)
+    {
+        var id = await GetPullRequestIdAsync(pullRequest);
+        await _graphQLClient.QueryAsync(DisableAutoMergeMutation, new Dictionary<string, object?> { ["id"] = id });
+        _log.Information($"Disabled auto-merge for {pullRequest.HtmlUrl}.");
+    }
+
+    private async Task<string> GetPullRequestIdAsync(IPullRequest pullRequest)
+    {
+        var owner = Validation.ParseOwnerFromGitHubURL(pullRequest.HtmlUrl);
+        var repo = Validation.ParseRepositoryFromGitHubURL(pullRequest.HtmlUrl);
+
+        var variables = new Dictionary<string, object?>
+        {
+            ["owner"] = owner,
+            ["repo"] = repo,
+            ["number"] = (int)pullRequest.Number,
+        };
+
+        var data = await _graphQLClient.QueryAsync(PullRequestIdQuery, variables);
+        var id = data?["repository"]?["pullRequest"]?["id"]?.ToString();
+
+        if (string.IsNullOrEmpty(id))
+        {
+            throw new InvalidOperationException($"Could not resolve the pull request id for {pullRequest.HtmlUrl}.");
+        }
+
+        return id;
+    }
+}

--- a/GitHubExtension/DataManager/Data/ProjectsDataManager.cs
+++ b/GitHubExtension/DataManager/Data/ProjectsDataManager.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Text.Json.Nodes;
+using GitHubExtension.Client;
+using GitHubExtension.Controls;
+using Serilog;
+
+namespace GitHubExtension.DataManager.Data;
+
+public sealed class ProjectsDataManager : IProjectsDataManager
+{
+    private const int DefaultPageSize = 30;
+
+    private const string MyProjectsQuery = @"
+query($first: Int!) {
+  viewer {
+    projectsV2(first: $first, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      nodes {
+        title
+        url
+        number
+        closed
+      }
+    }
+  }
+}";
+
+    private static readonly Lazy<ILogger> _logger = new(() => Serilog.Log.ForContext("SourceContext", nameof(ProjectsDataManager)));
+
+    private static readonly ILogger _log = _logger.Value;
+
+    private readonly IGitHubGraphQLClient _graphQLClient;
+
+    public ProjectsDataManager(IGitHubGraphQLClient graphQLClient)
+    {
+        _graphQLClient = graphQLClient;
+    }
+
+    public async Task<IEnumerable<IProject>> GetMyProjectsAsync()
+    {
+        var variables = new Dictionary<string, object?>
+        {
+            ["first"] = DefaultPageSize,
+        };
+
+        var data = await _graphQLClient.QueryAsync(MyProjectsQuery, variables);
+        var nodes = data?["viewer"]?["projectsV2"]?["nodes"] as JsonArray;
+
+        if (nodes == null)
+        {
+            _log.Debug("Projects query returned no nodes.");
+            return Array.Empty<IProject>();
+        }
+
+        var projects = new List<IProject>();
+        foreach (var node in nodes)
+        {
+            if (node == null)
+            {
+                continue;
+            }
+
+            projects.Add(ToProject(node));
+        }
+
+        _log.Debug($"Projects query returned {projects.Count} projects.");
+        return projects;
+    }
+
+    private static Project ToProject(JsonNode node)
+    {
+        return new Project
+        {
+            Title = node["title"]?.ToString() ?? string.Empty,
+            HtmlUrl = node["url"]?.ToString() ?? string.Empty,
+            Number = ParseLong(node["number"]),
+            Closed = node["closed"]?.GetValue<bool>() ?? false,
+        };
+    }
+
+    private static long ParseLong(JsonNode? node)
+    {
+        if (node != null && long.TryParse(node.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+        {
+            return value;
+        }
+
+        return 0;
+    }
+}

--- a/GitHubExtension/DataManager/IDiscussionsDataManager.cs
+++ b/GitHubExtension/DataManager/IDiscussionsDataManager.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Controls;
+
+namespace GitHubExtension.DataManager;
+
+public interface IDiscussionsDataManager
+{
+    // Searches discussions using GitHub search syntax (GraphQL search with
+    // type DISCUSSION). Pass "author:@me" for the user's own discussions.
+    Task<IEnumerable<IDiscussion>> SearchDiscussionsAsync(string query);
+}

--- a/GitHubExtension/DataManager/IGitHubAutoMergeManager.cs
+++ b/GitHubExtension/DataManager/IGitHubAutoMergeManager.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Controls;
+
+namespace GitHubExtension.DataManager;
+
+public interface IGitHubAutoMergeManager
+{
+    // Enables auto-merge on a pull request. GraphQL only.
+    Task EnableAutoMergeAsync(IPullRequest pullRequest);
+
+    // Disables auto-merge on a pull request. GraphQL only.
+    Task DisableAutoMergeAsync(IPullRequest pullRequest);
+}

--- a/GitHubExtension/DataManager/IProjectsDataManager.cs
+++ b/GitHubExtension/DataManager/IProjectsDataManager.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Controls;
+
+namespace GitHubExtension.DataManager;
+
+public interface IProjectsDataManager
+{
+    // Returns the signed-in user's Projects (v2), via the GraphQL viewer field.
+    Task<IEnumerable<IProject>> GetMyProjectsAsync();
+}

--- a/GitHubExtension/GitHubExtensionCommandsProvider.cs
+++ b/GitHubExtension/GitHubExtensionCommandsProvider.cs
@@ -30,6 +30,9 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
     private readonly IGitHubCreateManager _createManager;
     private readonly WorkflowRunsPage _workflowRunsPage;
     private readonly IWorkflowRunsDataManager _workflowRunsDataManager;
+    private readonly DiscussionsPage _myDiscussionsPage;
+    private readonly DiscussionsPage _searchDiscussionsPage;
+    private readonly ProjectsPage _projectsPage;
 
     public GitHubExtensionCommandsProvider(
         SavedSearchesPage savedSearchesPage,
@@ -45,7 +48,10 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
         NotificationsMediator notificationsMediator,
         IGitHubCreateManager createManager,
         WorkflowRunsPage workflowRunsPage,
-        IWorkflowRunsDataManager workflowRunsDataManager)
+        IWorkflowRunsDataManager workflowRunsDataManager,
+        DiscussionsPage myDiscussionsPage,
+        DiscussionsPage searchDiscussionsPage,
+        ProjectsPage projectsPage)
     {
         _savedSearchesPage = savedSearchesPage;
         _signOutPage = signOutPage;
@@ -61,6 +67,9 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
         _createManager = createManager;
         _workflowRunsPage = workflowRunsPage;
         _workflowRunsDataManager = workflowRunsDataManager;
+        _myDiscussionsPage = myDiscussionsPage;
+        _searchDiscussionsPage = searchDiscussionsPage;
+        _projectsPage = projectsPage;
 
         DisplayName = _resources.GetResource("ExtensionTitle");
 
@@ -122,6 +131,9 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
             BuildCreateBranchCommandItem(),
             BuildWorkflowRunsCommandItem(),
             BuildTriggerWorkflowCommandItem(),
+            BuildMyDiscussionsCommandItem(),
+            BuildSearchDiscussionsCommandItem(),
+            BuildProjectsCommandItem(),
             new(_savedSearchesPage),
             new(_signOutPage),
         };
@@ -204,6 +216,33 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
         {
             Title = _resources.GetResource("CommandsProvider_TriggerWorkflowCommandName"),
             Subtitle = _resources.GetResource("CommandsProvider_TriggerWorkflowSubtitle"),
+        };
+    }
+
+    private CommandItem BuildMyDiscussionsCommandItem()
+    {
+        return new CommandItem(_myDiscussionsPage)
+        {
+            Title = _resources.GetResource("CommandsProvider_MyDiscussionsCommandName"),
+            Subtitle = _resources.GetResource("CommandsProvider_MyDiscussionsSubtitle"),
+        };
+    }
+
+    private CommandItem BuildSearchDiscussionsCommandItem()
+    {
+        return new CommandItem(_searchDiscussionsPage)
+        {
+            Title = _resources.GetResource("CommandsProvider_SearchDiscussionsCommandName"),
+            Subtitle = _resources.GetResource("CommandsProvider_SearchDiscussionsSubtitle"),
+        };
+    }
+
+    private CommandItem BuildProjectsCommandItem()
+    {
+        return new CommandItem(_projectsPage)
+        {
+            Title = _resources.GetResource("CommandsProvider_ProjectsCommandName"),
+            Subtitle = _resources.GetResource("CommandsProvider_ProjectsSubtitle"),
         };
     }
 

--- a/GitHubExtension/Helpers/GitHubIcon.cs
+++ b/GitHubExtension/Helpers/GitHubIcon.cs
@@ -27,6 +27,8 @@ public static class GitHubIcon
                 { "notification", new IconInfo("\uEA8F") },
                 { "Notifications", new IconInfo("\uEA8F") },
                 { "Workflows", new IconInfo("\uE9F5") },
+                { "Discussions", new IconInfo("\uE8F2") },
+                { "Projects", new IconInfo("\uE8A1") },
             };
     }
 

--- a/GitHubExtension/Program.cs
+++ b/GitHubExtension/Program.cs
@@ -141,9 +141,18 @@ public class Program
         var workflowRunsDataManager = new WorkflowRunsDataManager(gitHubClientProvider);
         var workflowRunsPage = new WorkflowRunsPage(workflowRunsDataManager, workflowRunsMediator, resources);
 
+        var graphQLClient = new GitHubGraphQLClient(gitHubClientProvider);
+        var discussionsDataManager = new DiscussionsDataManager(graphQLClient);
+        var projectsDataManager = new ProjectsDataManager(graphQLClient);
+        var autoMergeManager = new GitHubAutoMergeManager(graphQLClient);
+
+        var myDiscussionsPage = new DiscussionsPage(discussionsDataManager, resources, resources.GetResource("Pages_MyDiscussions"), "author:@me");
+        var searchDiscussionsPage = new DiscussionsPage(discussionsDataManager, resources, resources.GetResource("Pages_SearchDiscussions"), string.Empty);
+        var projectsPage = new ProjectsPage(projectsDataManager, resources);
+
         var mutationManager = new GitHubMutationManager(gitHubClientProvider);
         var createManager = new GitHubCreateManager(gitHubClientProvider);
-        var mutationCommandsFactory = new MutationCommandsFactory(mutationManager, createManager, mutationMediator, resources);
+        var mutationCommandsFactory = new MutationCommandsFactory(mutationManager, createManager, autoMergeManager, mutationMediator, resources);
 
         var searchPageFactory = new SearchPageFactory(cacheDataManager, searchRepository, resources, savedSearchesMediator, mutationCommandsFactory, mutationMediator);
 
@@ -159,7 +168,7 @@ public class Program
         using var signInForm = new SignInForm(authenticationMediator, resources, developerIdProvider, signInCommand);
         using var signInPage = new SignInPage(signInForm, resources, signInCommand, authenticationMediator);
 
-        using var commandProvider = new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, notificationsPage, developerIdProvider, searchRepository, resources, searchPageFactory, savedSearchesMediator, authenticationMediator, notificationsMediator, createManager, workflowRunsPage, workflowRunsDataManager);
+        using var commandProvider = new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, notificationsPage, developerIdProvider, searchRepository, resources, searchPageFactory, savedSearchesMediator, authenticationMediator, notificationsMediator, createManager, workflowRunsPage, workflowRunsDataManager, myDiscussionsPage, searchDiscussionsPage, projectsPage);
         var extensionInstance = new GitHubExtension(extensionDisposedEvent, commandProvider);
 
         // We are instantiating an extension instance once above, and returning it every time the callback in RegisterExtension below is called.

--- a/GitHubExtension/Strings/en-US/Resources.resw
+++ b/GitHubExtension/Strings/en-US/Resources.resw
@@ -813,4 +813,88 @@
     <value>Trigger workflow</value>
     <comment>Submit button title for the Trigger Workflow form</comment>
   </data>
+  <data name="CommandsProvider_MyDiscussionsCommandName" xml:space="preserve">
+    <value>My discussions</value>
+    <comment>Name of the top-level My Discussions command</comment>
+  </data>
+  <data name="CommandsProvider_MyDiscussionsSubtitle" xml:space="preserve">
+    <value>Discussions you started</value>
+    <comment>Subtitle of the top-level My Discussions command</comment>
+  </data>
+  <data name="CommandsProvider_SearchDiscussionsCommandName" xml:space="preserve">
+    <value>Search discussions</value>
+    <comment>Name of the top-level Search Discussions command</comment>
+  </data>
+  <data name="CommandsProvider_SearchDiscussionsSubtitle" xml:space="preserve">
+    <value>Search GitHub discussions</value>
+    <comment>Subtitle of the top-level Search Discussions command</comment>
+  </data>
+  <data name="CommandsProvider_ProjectsCommandName" xml:space="preserve">
+    <value>My projects</value>
+    <comment>Name of the top-level My Projects command</comment>
+  </data>
+  <data name="CommandsProvider_ProjectsSubtitle" xml:space="preserve">
+    <value>Your GitHub Projects</value>
+    <comment>Subtitle of the top-level My Projects command</comment>
+  </data>
+  <data name="Pages_MyDiscussions" xml:space="preserve">
+    <value>My discussions</value>
+    <comment>Title of the My Discussions page</comment>
+  </data>
+  <data name="Pages_SearchDiscussions" xml:space="preserve">
+    <value>Search discussions</value>
+    <comment>Title of the Search Discussions page</comment>
+  </data>
+  <data name="Pages_Discussions_Placeholder" xml:space="preserve">
+    <value>Search discussions</value>
+    <comment>Placeholder text in the Discussions search box</comment>
+  </data>
+  <data name="Pages_Discussions_Prompt" xml:space="preserve">
+    <value>Type to search discussions</value>
+    <comment>Prompt shown on the Discussions page before a search is entered</comment>
+  </data>
+  <data name="Pages_Discussions_None" xml:space="preserve">
+    <value>No discussions found</value>
+    <comment>Message shown when no discussions match the search</comment>
+  </data>
+  <data name="Pages_Projects" xml:space="preserve">
+    <value>My projects</value>
+    <comment>Title of the Projects page</comment>
+  </data>
+  <data name="Pages_Projects_None" xml:space="preserve">
+    <value>No projects found</value>
+    <comment>Message shown when the user has no projects</comment>
+  </data>
+  <data name="Pages_Projects_Open" xml:space="preserve">
+    <value>Open</value>
+    <comment>Subtitle shown for an open project</comment>
+  </data>
+  <data name="Pages_Projects_Closed" xml:space="preserve">
+    <value>Closed</value>
+    <comment>Subtitle shown for a closed project</comment>
+  </data>
+  <data name="Commands_EnableAutoMerge" xml:space="preserve">
+    <value>Enable auto-merge</value>
+    <comment>Command name for enabling auto-merge on a pull request</comment>
+  </data>
+  <data name="Commands_DisableAutoMerge" xml:space="preserve">
+    <value>Disable auto-merge</value>
+    <comment>Command name for disabling auto-merge on a pull request</comment>
+  </data>
+  <data name="Message_EnableAutoMerge_Success" xml:space="preserve">
+    <value>Auto-merge enabled</value>
+    <comment>Success toast shown after enabling auto-merge</comment>
+  </data>
+  <data name="Message_EnableAutoMerge_Error" xml:space="preserve">
+    <value>Failed to enable auto-merge</value>
+    <comment>Error toast shown when enabling auto-merge fails</comment>
+  </data>
+  <data name="Message_DisableAutoMerge_Success" xml:space="preserve">
+    <value>Auto-merge disabled</value>
+    <comment>Success toast shown after disabling auto-merge</comment>
+  </data>
+  <data name="Message_DisableAutoMerge_Error" xml:space="preserve">
+    <value>Failed to disable auto-merge</value>
+    <comment>Error toast shown when disabling auto-merge fails</comment>
+  </data>
 </root>


### PR DESCRIPTION
Part of the RayCast parity roadmap. Stacked on top of #292 (M5).

## What this adds
Introduces a minimal **GraphQL client** alongside the Octokit REST client to reach capabilities REST does not expose.

- **GraphQL foundation**: GitHubGraphQLClient / IGitHubGraphQLClient POST queries + mutations using the signed-in developer's OAuth token. The GraphQL endpoint is derived from the REST base address, so github.com works today and GHES (M8) will work once the host is configurable.
- **Discussions (My + Search)**: \DiscussionsPage\ is a \DynamicListPage\; the user types a search query and results come from GraphQL \search(type: DISCUSSION)\. Top-level **My Discussions** (\uthor:@me\) and **Search Discussions** commands.
- **Projects (My)**: \ProjectsPage\ lists the signed-in user's Projects v2 via \iewer.projectsV2\. Top-level **My Projects** command.
- **Enable/Disable Auto-merge** (deferred from M3): GraphQL-only mutation. \GitHubAutoMergeManager\ resolves the PR node id then calls \nablePullRequestAutoMerge\ / \disablePullRequestAutoMerge\. Wired into \MutationCommandsFactory\ so open PRs now offer Enable and Disable auto-merge.
- Discussions/Projects icons, ResW strings, composition-root wiring.

## Tests
- Endpoint resolution (github.com + GHES), discussion/project mapping, auto-merge resolve-then-mutate, page rendering.
- **201/201 tests pass.**

## Notes
- Discussions/Projects are live-fetch (like Notifications/Workflow Runs), kept out of the search-keyed SQLite cache.
- Both Enable and Disable auto-merge are offered since current auto-merge state is not queried up front.