### PR TITLE
M7: Local clone (Download Repository)

### DIFF
--- a/GitHubExtension.Test/Controls/LocalCloneTests.cs
+++ b/GitHubExtension.Test/Controls/LocalCloneTests.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using GitHubExtension.Controls.Forms;
+using GitHubExtension.DataManager;
+using GitHubExtension.DataManager.Data;
+using GitHubExtension.Helpers;
+using Moq;
+
+namespace GitHubExtension.Test.Controls;
+
+[TestClass]
+public class LocalCloneTests
+{
+    private static Mock<IResources> CreateResources()
+    {
+        var resources = new Mock<IResources>();
+        resources.Setup(x => x.GetResource(It.IsAny<string>(), null)).Returns<string, object>((key, _) => key);
+        return resources;
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void ResolveCloneUrl_OwnerRepo_BuildsHttpsUrl()
+    {
+        var (cloneUrl, name) = RepositoryCloneManager.ResolveCloneUrl("octocat/Hello-World");
+
+        Assert.AreEqual("https://github.com/octocat/Hello-World.git", cloneUrl);
+        Assert.AreEqual("Hello-World", name);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void ResolveCloneUrl_FullUrl_UsedAsIsAndStripsGitSuffix()
+    {
+        var (cloneUrl, name) = RepositoryCloneManager.ResolveCloneUrl("https://github.com/octocat/Hello-World.git");
+
+        Assert.AreEqual("https://github.com/octocat/Hello-World.git", cloneUrl);
+        Assert.AreEqual("Hello-World", name);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void ResolveCloneUrl_HtmlUrl_DerivesRepositoryName()
+    {
+        var (cloneUrl, name) = RepositoryCloneManager.ResolveCloneUrl("https://github.com/octocat/Hello-World");
+
+        Assert.AreEqual("https://github.com/octocat/Hello-World", cloneUrl);
+        Assert.AreEqual("Hello-World", name);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public async Task CloneRepositoryAsync_GitMissing_Throws()
+    {
+        var gitService = new Mock<IGitService>();
+        gitService.Setup(x => x.IsGitInstalled()).Returns(false);
+        var settingsStore = new Mock<ICloneSettingsStore>();
+        var manager = new RepositoryCloneManager(gitService.Object, settingsStore.Object);
+
+        await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            () => manager.CloneRepositoryAsync("octocat/Hello-World"));
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public async Task CloneRepositoryAsync_UsesConfiguredBaseDirectory_AndReturnsDestination()
+    {
+        var baseDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var gitService = new Mock<IGitService>();
+        gitService.Setup(x => x.IsGitInstalled()).Returns(true);
+        string? capturedUrl = null;
+        string? capturedDestination = null;
+        gitService
+            .Setup(x => x.CloneAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, CancellationToken>((url, destination, _) =>
+            {
+                capturedUrl = url;
+                capturedDestination = destination;
+            })
+            .Returns(Task.CompletedTask);
+        var settingsStore = new Mock<ICloneSettingsStore>();
+        settingsStore.Setup(x => x.GetCloneBaseDirectoryAsync()).ReturnsAsync(baseDirectory);
+        var manager = new RepositoryCloneManager(gitService.Object, settingsStore.Object);
+
+        var result = await manager.CloneRepositoryAsync("octocat/Hello-World");
+
+        Assert.AreEqual(Path.Combine(baseDirectory, "Hello-World"), result);
+        Assert.AreEqual("https://github.com/octocat/Hello-World.git", capturedUrl);
+        Assert.AreEqual(Path.Combine(baseDirectory, "Hello-World"), capturedDestination);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public async Task CloneRepositoryAsync_ExplicitTargetDirectory_OverridesSettings()
+    {
+        var explicitDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var gitService = new Mock<IGitService>();
+        gitService.Setup(x => x.IsGitInstalled()).Returns(true);
+        gitService
+            .Setup(x => x.CloneAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var settingsStore = new Mock<ICloneSettingsStore>();
+        var manager = new RepositoryCloneManager(gitService.Object, settingsStore.Object);
+
+        var result = await manager.CloneRepositoryAsync("octocat/Hello-World", explicitDirectory);
+
+        Assert.AreEqual(Path.Combine(explicitDirectory, "Hello-World"), result);
+        settingsStore.Verify(x => x.GetCloneBaseDirectoryAsync(), Times.Never);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void CloneSettingsStore_DefaultBaseDirectory_IsUnderUserProfile()
+    {
+        var store = new CloneSettingsStore();
+
+        var defaultDirectory = store.GetDefaultCloneBaseDirectory();
+
+        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        Assert.AreEqual(Path.Combine(userProfile, "source", "repos"), defaultDirectory);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void CloneRepositoryForm_RendersValidTemplateJson()
+    {
+        var resources = CreateResources();
+        var cloneManager = new Mock<IRepositoryCloneManager>();
+        var settingsStore = new Mock<ICloneSettingsStore>();
+        settingsStore.Setup(x => x.GetDefaultCloneBaseDirectory()).Returns("C:\\src");
+
+        var form = new CloneRepositoryForm(cloneManager.Object, settingsStore.Object, resources.Object);
+
+        var json = form.TemplateJson;
+        Assert.IsFalse(string.IsNullOrWhiteSpace(json));
+        using var document = JsonDocument.Parse(json);
+        Assert.AreEqual("AdaptiveCard", document.RootElement.GetProperty("type").GetString());
+    }
+}

--- a/GitHubExtension.Test/Controls/SearchPagesTests.cs
+++ b/GitHubExtension.Test/Controls/SearchPagesTests.cs
@@ -54,7 +54,7 @@ public class SearchPagesTests
         Assert.IsNotNull(pullRequestsSearchPage);
 
         search.Setup(x => x.Type).Returns(SearchType.Repositories);
-        var repositoriesSearchPage = new RepositoriesSearchPage(search.Object, cacheDataManager.Object, resources.Object);
+        var repositoriesSearchPage = new RepositoriesSearchPage(search.Object, cacheDataManager.Object, resources.Object, new Mock<IRepositoryCloneManager>().Object);
         Assert.IsNotNull(repositoriesSearchPage);
     }
 
@@ -64,7 +64,7 @@ public class SearchPagesTests
     {
         var (cacheDataManager, resources, search) = CreateCommonMocks(SearchType.Repositories, "test search string type:repository");
 
-        var page = new RepositoriesSearchPage(search.Object, cacheDataManager.Object, resources.Object);
+        var page = new RepositoriesSearchPage(search.Object, cacheDataManager.Object, resources.Object, new Mock<IRepositoryCloneManager>().Object);
 
         var repo1 = new Mock<IRepository>();
         var repo2 = new Mock<IRepository>();

--- a/GitHubExtension.Test/Controls/TopLevelSearchesTest.cs
+++ b/GitHubExtension.Test/Controls/TopLevelSearchesTest.cs
@@ -117,7 +117,7 @@ public class TopLevelSearchesTest
             var autoMergeManager = new Mock<IGitHubAutoMergeManager>().Object;
             var mutationMediator = new MutationMediator();
             var mutationCommandsFactory = new MutationCommandsFactory(mutationManager, createManager, autoMergeManager, mutationMediator, resources);
-            var searchPageFactory = new SearchPageFactory(mockCacheDataManager, persistentDataManager, resources, mediator, mutationCommandsFactory, mutationMediator);
+            var searchPageFactory = new SearchPageFactory(mockCacheDataManager, persistentDataManager, resources, mediator, mutationCommandsFactory, mutationMediator, new Mock<IRepositoryCloneManager>().Object);
 
             var addSearchForm = new SaveSearchForm(persistentDataManager, resources, mediator);
 

--- a/GitHubExtension.Test/Helpers/TestSetupHelpers.cs
+++ b/GitHubExtension.Test/Helpers/TestSetupHelpers.cs
@@ -184,6 +184,8 @@ public partial class TestHelpers
         var searchDiscussionsPage = new DiscussionsPage(mockDiscussionsDataManager.Object, mockResources, "Search discussions", string.Empty);
         var mockProjectsDataManager = new Mock<IProjectsDataManager>();
         var projectsPage = new ProjectsPage(mockProjectsDataManager.Object, mockResources);
-        return new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, notificationsPage, mockDeveloperIdProvider, persistentDataManager, mockResources, searchPageFactory, savedSearchesMediator, mockAuthenticationMediator, notificationsMediator, mockCreateManager, workflowRunsPage, mockWorkflowRunsDataManager.Object, myDiscussionsPage, searchDiscussionsPage, projectsPage);
+        var mockCloneManager = new Mock<IRepositoryCloneManager>().Object;
+        var mockCloneSettingsStore = new Mock<ICloneSettingsStore>().Object;
+        return new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, notificationsPage, mockDeveloperIdProvider, persistentDataManager, mockResources, searchPageFactory, savedSearchesMediator, mockAuthenticationMediator, notificationsMediator, mockCreateManager, workflowRunsPage, mockWorkflowRunsDataManager.Object, myDiscussionsPage, searchDiscussionsPage, projectsPage, mockCloneManager, mockCloneSettingsStore);
     }
 }

--- a/GitHubExtension/Controls/Commands/CloneRepositoryCommand.cs
+++ b/GitHubExtension/Controls/Commands/CloneRepositoryCommand.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.DataManager;
+using GitHubExtension.Helpers;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Serilog;
+
+namespace GitHubExtension.Controls.Commands;
+
+// Clones a repository from a list item into the configured clone base directory,
+// showing a success or error toast. The clone runs synchronously within Invoke
+// so the toast reflects the final outcome.
+internal sealed partial class CloneRepositoryCommand : InvokableCommand
+{
+    private static readonly ILogger _log = Log.ForContext("SourceContext", nameof(CloneRepositoryCommand));
+
+    private readonly IRepository _repository;
+    private readonly IRepositoryCloneManager _cloneManager;
+    private readonly IResources _resources;
+
+    internal CloneRepositoryCommand(IRepository repository, IRepositoryCloneManager cloneManager, IResources resources)
+    {
+        _repository = repository;
+        _cloneManager = cloneManager;
+        _resources = resources;
+        Name = resources.GetResource("Commands_CloneRepository");
+        Icon = new IconInfo("\uE896");
+    }
+
+    public override CommandResult Invoke()
+    {
+        try
+        {
+            var cloneSource = string.IsNullOrWhiteSpace(_repository.CloneUrl) ? _repository.FullName : _repository.CloneUrl;
+            _cloneManager.CloneRepositoryAsync(cloneSource).GetAwaiter().GetResult();
+            ToastHelper.ShowSuccessToast(_resources.GetResource("Message_CloneRepository_Success"));
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to clone repository.");
+            ToastHelper.ShowErrorToast(_resources.GetResource("Message_CloneRepository_Error"));
+        }
+
+        return CommandResult.KeepOpen();
+    }
+}

--- a/GitHubExtension/Controls/Forms/CloneRepositoryForm.cs
+++ b/GitHubExtension/Controls/Forms/CloneRepositoryForm.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using GitHubExtension.DataManager;
+using GitHubExtension.Helpers;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace GitHubExtension.Controls.Forms;
+
+public sealed partial class CloneRepositoryForm : FormContent, IGitHubForm
+{
+    private readonly IRepositoryCloneManager _cloneManager;
+    private readonly ICloneSettingsStore _settingsStore;
+    private readonly IResources _resources;
+    private readonly string _initialRepository;
+
+    public event EventHandler<bool>? LoadingStateChanged;
+
+    public event EventHandler<FormSubmitEventArgs>? FormSubmitted;
+
+    public CloneRepositoryForm(IRepositoryCloneManager cloneManager, ICloneSettingsStore settingsStore, IResources resources, string initialRepository = "")
+    {
+        _cloneManager = cloneManager;
+        _settingsStore = settingsStore;
+        _resources = resources;
+        _initialRepository = initialRepository;
+    }
+
+    public Dictionary<string, string> TemplateSubstitutions => new()
+    {
+        { "{{CloneRepositoryFormTitle}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Clone_Title")) },
+        { "{{RepositoryLabel}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Clone_RepositoryLabel")) },
+        { "{{RepositoryPlaceholder}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Clone_RepositoryPlaceholder")) },
+        { "{{RepositoryErrorMessage}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Clone_RepositoryError")) },
+        { "{{RepositoryValue}}", JsonSerializer.Serialize(_initialRepository) },
+        { "{{TargetDirectoryLabel}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Clone_TargetDirectoryLabel")) },
+        { "{{TargetDirectoryPlaceholder}}", JsonSerializer.Serialize(_settingsStore.GetDefaultCloneBaseDirectory()) },
+        { "{{CloneRepositoryActionTitle}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Clone_Action")) },
+    };
+
+    public override string TemplateJson => TemplateHelper.LoadTemplateJsonFromTemplateName("CloneRepository", TemplateSubstitutions);
+
+    public override ICommandResult SubmitForm(string? inputs, string data)
+    {
+        LoadingStateChanged?.Invoke(this, true);
+        _ = SubmitInternalAsync(inputs);
+        return CommandResult.KeepOpen();
+    }
+
+    private async Task SubmitInternalAsync(string? inputs)
+    {
+        try
+        {
+            var payload = JsonNode.Parse(inputs ?? string.Empty) ?? throw new InvalidOperationException("No input provided.");
+            var repository = payload["Repository"]?.ToString() ?? string.Empty;
+            var targetDirectory = payload["TargetDirectory"]?.ToString() ?? string.Empty;
+
+            await _cloneManager.CloneRepositoryAsync(repository, targetDirectory);
+
+            LoadingStateChanged?.Invoke(this, false);
+            FormSubmitted?.Invoke(this, new FormSubmitEventArgs(true, null));
+        }
+        catch (Exception ex)
+        {
+            LoadingStateChanged?.Invoke(this, false);
+            FormSubmitted?.Invoke(this, new FormSubmitEventArgs(false, ex));
+        }
+    }
+}

--- a/GitHubExtension/Controls/Pages/SearchPages/RepositoriesSearchPage.cs
+++ b/GitHubExtension/Controls/Pages/SearchPages/RepositoriesSearchPage.cs
@@ -3,14 +3,17 @@
 // See the LICENSE file in the project root for more information.
 
 using GitHubExtension.Controls.Commands;
+using GitHubExtension.DataManager;
 using GitHubExtension.Helpers;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 
 namespace GitHubExtension.Controls.Pages;
 
-public sealed partial class RepositoriesSearchPage(ISearch search, ICacheDataManager cacheDataManager, IResources resources)
+public sealed partial class RepositoriesSearchPage(ISearch search, ICacheDataManager cacheDataManager, IResources resources, IRepositoryCloneManager cloneManager)
     : SearchPage<IRepository>(search, cacheDataManager, resources)
 {
+    private readonly IRepositoryCloneManager _cloneManager = cloneManager;
+
     protected override ListItem GetListItem(IRepository item)
     {
         return new ListItem(new LinkCommand(item, Resources))
@@ -22,6 +25,7 @@ public sealed partial class RepositoriesSearchPage(ISearch search, ICacheDataMan
             {
                 new(new CopyCommand(item.HtmlUrl, $"{Resources.GetResource("Commands_CopyURL")}", Resources)),
                 new(new CopyCommand(item.CloneUrl, $"{Resources.GetResource("Commands_Copy_CloneUrl")}", Resources)),
+                new(new CloneRepositoryCommand(item, _cloneManager, Resources)),
             },
         };
     }

--- a/GitHubExtension/Controls/Pages/SearchPages/SearchPageFactory.cs
+++ b/GitHubExtension/Controls/Pages/SearchPages/SearchPageFactory.cs
@@ -4,6 +4,7 @@
 
 using GitHubExtension.Controls.Commands;
 using GitHubExtension.Controls.Forms;
+using GitHubExtension.DataManager;
 using GitHubExtension.DataModel.Enums;
 using GitHubExtension.Helpers;
 using Microsoft.CommandPalette.Extensions;
@@ -19,8 +20,9 @@ public class SearchPageFactory : ISearchPageFactory
     private readonly SavedSearchesMediator _savedSearchesMediator;
     private readonly MutationCommandsFactory _mutationCommandsFactory;
     private readonly MutationMediator _mutationMediator;
+    private readonly IRepositoryCloneManager _cloneManager;
 
-    public SearchPageFactory(ICacheDataManager cacheDataManager, ISearchRepository searchRepository, IResources resources, SavedSearchesMediator savedSearchesMediator, MutationCommandsFactory mutationCommandsFactory, MutationMediator mutationMediator)
+    public SearchPageFactory(ICacheDataManager cacheDataManager, ISearchRepository searchRepository, IResources resources, SavedSearchesMediator savedSearchesMediator, MutationCommandsFactory mutationCommandsFactory, MutationMediator mutationMediator, IRepositoryCloneManager cloneManager)
     {
         _cacheDataManager = cacheDataManager;
         _searchRepository = searchRepository;
@@ -28,6 +30,7 @@ public class SearchPageFactory : ISearchPageFactory
         _savedSearchesMediator = savedSearchesMediator;
         _mutationCommandsFactory = mutationCommandsFactory;
         _mutationMediator = mutationMediator;
+        _cloneManager = cloneManager;
     }
 
     private ListPage CreatePageForSearch(ISearch search)
@@ -36,7 +39,7 @@ public class SearchPageFactory : ISearchPageFactory
         {
             SearchType.PullRequests => new PullRequestsSearchPage(search, _cacheDataManager, _resources, _mutationCommandsFactory, _mutationMediator),
             SearchType.Issues => new IssuesSearchPage(search, _cacheDataManager, _resources, _mutationCommandsFactory, _mutationMediator),
-            SearchType.Repositories => new RepositoriesSearchPage(search, _cacheDataManager, _resources),
+            SearchType.Repositories => new RepositoriesSearchPage(search, _cacheDataManager, _resources, _cloneManager),
             _ => new CombinedSearchPage(search, _cacheDataManager, _resources, _mutationCommandsFactory, _mutationMediator),
         };
     }

--- a/GitHubExtension/Controls/Templates/CloneRepositoryTemplate.json
+++ b/GitHubExtension/Controls/Templates/CloneRepositoryTemplate.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "type": "AdaptiveCard",
+  "version": "1.5",
+  "body": [
+    {
+      "type": "TextBlock",
+      "size": "Medium",
+      "weight": "Bolder",
+      "text": {{CloneRepositoryFormTitle}},
+      "horizontalAlignment": "Center",
+      "wrap": true,
+      "style": "heading"
+    },
+    {
+      "type": "Input.Text",
+      "id": "Repository",
+      "label": {{RepositoryLabel}},
+      "placeholder": {{RepositoryPlaceholder}},
+      "isRequired": true,
+      "errorMessage": {{RepositoryErrorMessage}},
+      "value": {{RepositoryValue}}
+    },
+    {
+      "type": "Input.Text",
+      "id": "TargetDirectory",
+      "label": {{TargetDirectoryLabel}},
+      "placeholder": {{TargetDirectoryPlaceholder}},
+      "isRequired": false
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.Submit",
+      "title": {{CloneRepositoryActionTitle}},
+      "data": {
+        "id": "CloneRepositoryAction"
+      }
+    }
+  ]
+}

--- a/GitHubExtension/DataManager/Data/CloneSettingsStore.cs
+++ b/GitHubExtension/DataManager/Data/CloneSettingsStore.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Helpers;
+
+namespace GitHubExtension.DataManager.Data;
+
+// ICloneSettingsStore backed by LocalSettings. The default clone location is
+// %USERPROFILE%\source\repos, matching the common Visual Studio convention and
+// staying inside a directory the user can normally write to.
+public sealed class CloneSettingsStore : ICloneSettingsStore
+{
+    private const string ClonePathSettingKey = "ClonePath";
+
+    public string GetDefaultCloneBaseDirectory()
+    {
+        return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "source", "repos");
+    }
+
+    public async Task<string> GetCloneBaseDirectoryAsync()
+    {
+        var configured = await LocalSettings.ReadSettingAsync<string>(ClonePathSettingKey);
+        return string.IsNullOrWhiteSpace(configured) ? GetDefaultCloneBaseDirectory() : configured!;
+    }
+
+    public async Task SetCloneBaseDirectoryAsync(string path)
+    {
+        await LocalSettings.SaveSettingAsync(ClonePathSettingKey, path);
+    }
+}

--- a/GitHubExtension/DataManager/Data/GitService.cs
+++ b/GitHubExtension/DataManager/Data/GitService.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using Serilog;
+
+namespace GitHubExtension.DataManager.Data;
+
+// Default IGitService backed by the local git executable. Git availability is
+// determined by locating git on the PATH, and cloning shells out to
+// "git clone <url> <destination>". Under MSIX the process launch and the target
+// directory are subject to the app sandbox; failures surface as exceptions that
+// the calling form/command turns into an error toast.
+public sealed class GitService : IGitService
+{
+    private static readonly ILogger _log = Log.ForContext("SourceContext", nameof(GitService));
+
+    public bool IsGitInstalled() => FindGitExecutable() != null;
+
+    public async Task CloneAsync(string cloneUrl, string destinationPath, CancellationToken cancellationToken = default)
+    {
+        var gitExecutable = FindGitExecutable()
+            ?? throw new InvalidOperationException("Git is not installed or could not be found on the PATH.");
+
+        var parentDirectory = Path.GetDirectoryName(destinationPath);
+        if (!string.IsNullOrEmpty(parentDirectory))
+        {
+            Directory.CreateDirectory(parentDirectory);
+        }
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = gitExecutable,
+            UseShellExecute = false,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            CreateNoWindow = true,
+        };
+        startInfo.ArgumentList.Add("clone");
+        startInfo.ArgumentList.Add(cloneUrl);
+        startInfo.ArgumentList.Add(destinationPath);
+
+        using var process = new Process { StartInfo = startInfo };
+        process.Start();
+
+        var standardError = await process.StandardError.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken);
+
+        if (process.ExitCode != 0)
+        {
+            _log.Error($"git clone failed with exit code {process.ExitCode}: {standardError}");
+            throw new InvalidOperationException($"git clone failed (exit code {process.ExitCode}): {standardError}");
+        }
+
+        _log.Information($"Cloned {cloneUrl} into {destinationPath}.");
+    }
+
+    private static string? FindGitExecutable()
+    {
+        var pathVariable = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(pathVariable))
+        {
+            return null;
+        }
+
+        foreach (var directory in pathVariable.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            try
+            {
+                var candidate = Path.Combine(directory, "git.exe");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+            catch (ArgumentException)
+            {
+                // Ignore malformed PATH entries.
+            }
+        }
+
+        return null;
+    }
+}

--- a/GitHubExtension/DataManager/Data/RepositoryCloneManager.cs
+++ b/GitHubExtension/DataManager/Data/RepositoryCloneManager.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Client;
+using Serilog;
+
+namespace GitHubExtension.DataManager.Data;
+
+public sealed class RepositoryCloneManager : IRepositoryCloneManager
+{
+    private static readonly ILogger _log = Log.ForContext("SourceContext", nameof(RepositoryCloneManager));
+
+    private readonly IGitService _gitService;
+    private readonly ICloneSettingsStore _settingsStore;
+
+    public RepositoryCloneManager(IGitService gitService, ICloneSettingsStore settingsStore)
+    {
+        _gitService = gitService;
+        _settingsStore = settingsStore;
+    }
+
+    public async Task<string> CloneRepositoryAsync(string repository, string? targetDirectory = null, CancellationToken cancellationToken = default)
+    {
+        if (!_gitService.IsGitInstalled())
+        {
+            throw new InvalidOperationException("Git is not installed or could not be found on the PATH.");
+        }
+
+        var (cloneUrl, repositoryName) = ResolveCloneUrl(repository);
+
+        var baseDirectory = string.IsNullOrWhiteSpace(targetDirectory)
+            ? await _settingsStore.GetCloneBaseDirectoryAsync()
+            : targetDirectory!.Trim();
+
+        var destination = Path.Combine(baseDirectory, repositoryName);
+
+        if (Directory.Exists(destination) && Directory.EnumerateFileSystemEntries(destination).Any())
+        {
+            throw new InvalidOperationException($"Destination directory '{destination}' already exists and is not empty.");
+        }
+
+        await _gitService.CloneAsync(cloneUrl, destination, cancellationToken);
+        _log.Information($"Cloned {cloneUrl} to {destination}.");
+        return destination;
+    }
+
+    internal static (string CloneUrl, string RepositoryName) ResolveCloneUrl(string repository)
+    {
+        if (string.IsNullOrWhiteSpace(repository))
+        {
+            throw new ArgumentException("Repository must be provided.", nameof(repository));
+        }
+
+        var trimmed = repository.Trim();
+
+        // A full URL (GitHub HTML URL or a clone URL) is used as-is; the repo
+        // name is the last path segment with any trailing ".git" removed.
+        if (Validation.IsValidHttpUri(trimmed, out var uri) && uri != null)
+        {
+            var name = uri.Segments.Length > 0 ? uri.Segments[^1].TrimEnd('/') : string.Empty;
+            if (name.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+            {
+                name = name[..^4];
+            }
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("Could not determine the repository name from the URL.", nameof(repository));
+            }
+
+            return (trimmed, name);
+        }
+
+        var (owner, repo) = GitHubCreateManager.ParseOwnerRepo(trimmed);
+        return ($"https://github.com/{owner}/{repo}.git", repo);
+    }
+}

--- a/GitHubExtension/DataManager/ICloneSettingsStore.cs
+++ b/GitHubExtension/DataManager/ICloneSettingsStore.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace GitHubExtension.DataManager;
+
+// Persists the configurable base directory into which repositories are cloned.
+public interface ICloneSettingsStore
+{
+    // Returns the platform default clone base directory (used when nothing is
+    // configured and as the placeholder in the clone form).
+    string GetDefaultCloneBaseDirectory();
+
+    // Returns the configured clone base directory, or the default when unset.
+    Task<string> GetCloneBaseDirectoryAsync();
+
+    // Persists the clone base directory preference.
+    Task SetCloneBaseDirectoryAsync(string path);
+}

--- a/GitHubExtension/DataManager/IGitService.cs
+++ b/GitHubExtension/DataManager/IGitService.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace GitHubExtension.DataManager;
+
+// Abstraction over the local git executable so the clone flow can be unit
+// tested without spawning a real process or requiring git on the machine.
+public interface IGitService
+{
+    // Returns true when a git executable can be located on the machine.
+    bool IsGitInstalled();
+
+    // Clones the repository at the given URL into the destination directory.
+    // Throws when git is unavailable or the clone fails.
+    Task CloneAsync(string cloneUrl, string destinationPath, CancellationToken cancellationToken = default);
+}

--- a/GitHubExtension/DataManager/IRepositoryCloneManager.cs
+++ b/GitHubExtension/DataManager/IRepositoryCloneManager.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace GitHubExtension.DataManager;
+
+// Coordinates cloning a GitHub repository to the local machine: resolves the
+// clone URL and destination directory, validates git availability, and delegates
+// the actual clone to IGitService.
+public interface IRepositoryCloneManager
+{
+    // Clones the given repository (an owner/repo string, a full GitHub URL, or a
+    // clone URL) into targetDirectory, or the configured base directory when
+    // targetDirectory is null/empty. Returns the local path of the clone.
+    Task<string> CloneRepositoryAsync(string repository, string? targetDirectory = null, CancellationToken cancellationToken = default);
+}

--- a/GitHubExtension/GitHubExtensionCommandsProvider.cs
+++ b/GitHubExtension/GitHubExtensionCommandsProvider.cs
@@ -33,6 +33,8 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
     private readonly DiscussionsPage _myDiscussionsPage;
     private readonly DiscussionsPage _searchDiscussionsPage;
     private readonly ProjectsPage _projectsPage;
+    private readonly IRepositoryCloneManager _cloneManager;
+    private readonly ICloneSettingsStore _cloneSettingsStore;
 
     public GitHubExtensionCommandsProvider(
         SavedSearchesPage savedSearchesPage,
@@ -51,7 +53,9 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
         IWorkflowRunsDataManager workflowRunsDataManager,
         DiscussionsPage myDiscussionsPage,
         DiscussionsPage searchDiscussionsPage,
-        ProjectsPage projectsPage)
+        ProjectsPage projectsPage,
+        IRepositoryCloneManager cloneManager,
+        ICloneSettingsStore cloneSettingsStore)
     {
         _savedSearchesPage = savedSearchesPage;
         _signOutPage = signOutPage;
@@ -70,6 +74,8 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
         _myDiscussionsPage = myDiscussionsPage;
         _searchDiscussionsPage = searchDiscussionsPage;
         _projectsPage = projectsPage;
+        _cloneManager = cloneManager;
+        _cloneSettingsStore = cloneSettingsStore;
 
         DisplayName = _resources.GetResource("ExtensionTitle");
 
@@ -134,6 +140,7 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
             BuildMyDiscussionsCommandItem(),
             BuildSearchDiscussionsCommandItem(),
             BuildProjectsCommandItem(),
+            BuildCloneRepositoryCommandItem(),
             new(_savedSearchesPage),
             new(_signOutPage),
         };
@@ -243,6 +250,23 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
         {
             Title = _resources.GetResource("CommandsProvider_ProjectsCommandName"),
             Subtitle = _resources.GetResource("CommandsProvider_ProjectsSubtitle"),
+        };
+    }
+
+    private CommandItem BuildCloneRepositoryCommandItem()
+    {
+        var page = new GitHubFormPage(
+            new CloneRepositoryForm(_cloneManager, _cloneSettingsStore, _resources),
+            _resources,
+            "Forms_Clone_Title",
+            "\uE896",
+            "Message_CloneRepository_Success",
+            "Message_CloneRepository_Error");
+
+        return new CommandItem(page)
+        {
+            Title = _resources.GetResource("CommandsProvider_CloneRepositoryCommandName"),
+            Subtitle = _resources.GetResource("CommandsProvider_CloneRepositorySubtitle"),
         };
     }
 

--- a/GitHubExtension/Helpers/TemplateHelper.cs
+++ b/GitHubExtension/Helpers/TemplateHelper.cs
@@ -19,6 +19,7 @@ public static class TemplateHelper
             "CreateBranch" => "Controls\\Templates\\CreateBranchTemplate.json",
             "AddComment" => "Controls\\Templates\\AddCommentTemplate.json",
             "TriggerWorkflow" => "Controls\\Templates\\TriggerWorkflowTemplate.json",
+            "CloneRepository" => "Controls\\Templates\\CloneRepositoryTemplate.json",
             _ => throw new NotImplementedException($"Template for page '{page}' is not implemented."),
         };
     }

--- a/GitHubExtension/Program.cs
+++ b/GitHubExtension/Program.cs
@@ -154,7 +154,11 @@ public class Program
         var createManager = new GitHubCreateManager(gitHubClientProvider);
         var mutationCommandsFactory = new MutationCommandsFactory(mutationManager, createManager, autoMergeManager, mutationMediator, resources);
 
-        var searchPageFactory = new SearchPageFactory(cacheDataManager, searchRepository, resources, savedSearchesMediator, mutationCommandsFactory, mutationMediator);
+        var gitService = new GitService();
+        var cloneSettingsStore = new CloneSettingsStore();
+        var cloneManager = new RepositoryCloneManager(gitService, cloneSettingsStore);
+
+        var searchPageFactory = new SearchPageFactory(cacheDataManager, searchRepository, resources, savedSearchesMediator, mutationCommandsFactory, mutationMediator, cloneManager);
 
         var addSearchForm = new SaveSearchForm(searchRepository, resources, savedSearchesMediator);
         var addSearchListItem = new AddSearchListItem(new SaveSearchPage(addSearchForm, new StatusMessage(), resources), resources);
@@ -168,7 +172,7 @@ public class Program
         using var signInForm = new SignInForm(authenticationMediator, resources, developerIdProvider, signInCommand);
         using var signInPage = new SignInPage(signInForm, resources, signInCommand, authenticationMediator);
 
-        using var commandProvider = new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, notificationsPage, developerIdProvider, searchRepository, resources, searchPageFactory, savedSearchesMediator, authenticationMediator, notificationsMediator, createManager, workflowRunsPage, workflowRunsDataManager, myDiscussionsPage, searchDiscussionsPage, projectsPage);
+        using var commandProvider = new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, notificationsPage, developerIdProvider, searchRepository, resources, searchPageFactory, savedSearchesMediator, authenticationMediator, notificationsMediator, createManager, workflowRunsPage, workflowRunsDataManager, myDiscussionsPage, searchDiscussionsPage, projectsPage, cloneManager, cloneSettingsStore);
         var extensionInstance = new GitHubExtension(extensionDisposedEvent, commandProvider);
 
         // We are instantiating an extension instance once above, and returning it every time the callback in RegisterExtension below is called.

--- a/GitHubExtension/Strings/en-US/Resources.resw
+++ b/GitHubExtension/Strings/en-US/Resources.resw
@@ -897,4 +897,48 @@
     <value>Failed to disable auto-merge</value>
     <comment>Error toast shown when disabling auto-merge fails</comment>
   </data>
+  <data name="CommandsProvider_CloneRepositoryCommandName" xml:space="preserve">
+    <value>Clone Repository</value>
+    <comment>Top-level command name for cloning a repository locally</comment>
+  </data>
+  <data name="CommandsProvider_CloneRepositorySubtitle" xml:space="preserve">
+    <value>Clone a GitHub repository to your machine</value>
+    <comment>Subtitle for the Clone Repository top-level command</comment>
+  </data>
+  <data name="Commands_CloneRepository" xml:space="preserve">
+    <value>Clone Repository</value>
+    <comment>Context command to clone the selected repository</comment>
+  </data>
+  <data name="Forms_Clone_Title" xml:space="preserve">
+    <value>Clone Repository</value>
+    <comment>Title of the clone repository form</comment>
+  </data>
+  <data name="Forms_Clone_RepositoryLabel" xml:space="preserve">
+    <value>Repository</value>
+    <comment>Label for the repository field on the clone form</comment>
+  </data>
+  <data name="Forms_Clone_RepositoryPlaceholder" xml:space="preserve">
+    <value>owner/repo or a GitHub URL</value>
+    <comment>Placeholder for the repository field on the clone form</comment>
+  </data>
+  <data name="Forms_Clone_RepositoryError" xml:space="preserve">
+    <value>Repository is required</value>
+    <comment>Validation error for the repository field on the clone form</comment>
+  </data>
+  <data name="Forms_Clone_TargetDirectoryLabel" xml:space="preserve">
+    <value>Target directory (optional)</value>
+    <comment>Label for the target directory field on the clone form</comment>
+  </data>
+  <data name="Message_CloneRepository_Success" xml:space="preserve">
+    <value>Repository cloned successfully</value>
+    <comment>Success toast shown after a repository is cloned</comment>
+  </data>
+  <data name="Message_CloneRepository_Error" xml:space="preserve">
+    <value>Failed to clone repository</value>
+    <comment>Error toast shown when cloning a repository fails</comment>
+  </data>
+  <data name="Forms_Clone_Action" xml:space="preserve">
+    <value>Clone</value>
+    <comment>Submit button label on the clone repository form</comment>
+  </data>
 </root>


### PR DESCRIPTION
Part of the RayCast parity roadmap. Stacked on top of #293 (M6).

## What this adds
Clone a GitHub repository to the local machine, respecting a configurable clone location and git availability.

- **Git detection + clone**: \IGitService\ / \GitService\ locate \git\ on the PATH and shell out to \git clone <url> <destination>\. Abstracted behind an interface so the clone flow is unit tested without a real git install or spawned process. MSIX sandbox constraints surface as clone failures turned into error toasts.
- **Configurable clone path**: \ICloneSettingsStore\ / \CloneSettingsStore\ persist the clone base directory via \LocalSettings\, defaulting to \%USERPROFILE%\\source\\repos\.
- **Clone orchestration**: \IRepositoryCloneManager\ / \RepositoryCloneManager\ resolve the clone URL (owner/repo, GitHub URL, or clone URL) and destination directory, validate git availability, guard against a non-empty destination, and return the local clone path.
- **Top-level Clone Repository command**: a \FormContent\ form with a repository field and an optional target directory (placeholder shows the default).
- **Per-item Clone action**: a Clone Repository action on the Repositories search page items, cloning from the repo's clone URL.

## Tests
- URL / owner-repo resolution, git-missing guard, configured vs explicit target directory, default-directory resolution, and form JSON rendering.
- **209/209 tests pass.**

## Notes
- \RuntimeHelper.IsMSIX\ currently returns false; the default clone directory stays inside the user profile so it works in both packaged and unpackaged runs.
- Repo/branch entry is text-input based, consistent with the other create/trigger forms.