### PR TITLE
M8: GitHub Enterprise Server support

### DIFF
--- a/GitHubExtension.Test/Controls/GitHubHostAddressTests.cs
+++ b/GitHubExtension.Test/Controls/GitHubHostAddressTests.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Client;
+
+namespace GitHubExtension.Test.Controls;
+
+[TestClass]
+public class GitHubHostAddressTests
+{
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void ParseHostInput_Empty_DefaultsToGitHubDotCom()
+    {
+        var uri = GitHubHostAddress.ParseHostInput(string.Empty);
+        Assert.AreEqual("github.com", uri.Host);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void ParseHostInput_BareHost_AssumesHttps()
+    {
+        var uri = GitHubHostAddress.ParseHostInput("github.example.com");
+        Assert.AreEqual(Uri.UriSchemeHttps, uri.Scheme);
+        Assert.AreEqual("github.example.com", uri.Host);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void ParseHostInput_WithScheme_Preserved()
+    {
+        var uri = GitHubHostAddress.ParseHostInput("https://github.example.com");
+        Assert.AreEqual("github.example.com", uri.Host);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void ParseHostInput_UnsupportedScheme_Throws()
+    {
+        Assert.ThrowsException<UriFormatException>(() => GitHubHostAddress.ParseHostInput("ftp://github.example.com"));
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void IsGitHubDotComHost_RecognizesCommonForms()
+    {
+        Assert.IsTrue(GitHubHostAddress.IsGitHubDotComHost("github.com"));
+        Assert.IsTrue(GitHubHostAddress.IsGitHubDotComHost("www.github.com"));
+        Assert.IsTrue(GitHubHostAddress.IsGitHubDotComHost("api.github.com"));
+        Assert.IsFalse(GitHubHostAddress.IsGitHubDotComHost("github.example.com"));
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void GetApiBaseUri_GitHubDotCom_UsesApiGitHubCom()
+    {
+        var host = GitHubHostAddress.ParseHostInput("github.com");
+        Assert.AreEqual("https://api.github.com/", GitHubHostAddress.GetApiBaseUri(host).ToString());
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void GetApiBaseUri_Enterprise_UsesApiV3Path()
+    {
+        var host = GitHubHostAddress.ParseHostInput("github.example.com");
+        Assert.AreEqual("https://github.example.com/api/v3/", GitHubHostAddress.GetApiBaseUri(host).ToString());
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void GetGraphQLUri_GitHubDotCom_UsesApiGitHubComGraphQL()
+    {
+        var host = GitHubHostAddress.ParseHostInput("github.com");
+        Assert.AreEqual("https://api.github.com/graphql", GitHubHostAddress.GetGraphQLUri(host).ToString());
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void GetGraphQLUri_Enterprise_UsesApiGraphQLPath()
+    {
+        var host = GitHubHostAddress.ParseHostInput("github.example.com");
+        Assert.AreEqual("https://github.example.com/api/graphql", GitHubHostAddress.GetGraphQLUri(host).ToString());
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void GetGraphQLUriFromApiBase_GitHubDotCom()
+    {
+        var apiBase = new Uri("https://api.github.com/");
+        Assert.AreEqual("https://api.github.com/graphql", GitHubHostAddress.GetGraphQLUriFromApiBase(apiBase).ToString());
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void GetGraphQLUriFromApiBase_Enterprise()
+    {
+        var apiBase = new Uri("https://github.example.com/api/v3/");
+        Assert.AreEqual("https://github.example.com/api/graphql", GitHubHostAddress.GetGraphQLUriFromApiBase(apiBase).ToString());
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void GraphQLClient_ResolveGraphQLEndpoint_DelegatesToHostAddress()
+    {
+        Assert.AreEqual(
+            "https://api.github.com/graphql",
+            GitHubGraphQLClient.ResolveGraphQLEndpoint(new Uri("https://api.github.com/")).ToString());
+        Assert.AreEqual(
+            "https://github.example.com/api/graphql",
+            GitHubGraphQLClient.ResolveGraphQLEndpoint(new Uri("https://github.example.com/api/v3/")).ToString());
+    }
+}

--- a/GitHubExtension/Client/GitHubGraphQLClient.cs
+++ b/GitHubExtension/Client/GitHubGraphQLClient.cs
@@ -79,16 +79,6 @@ public sealed class GitHubGraphQLClient : IGitHubGraphQLClient
 
     internal static Uri ResolveGraphQLEndpoint(Uri baseAddress)
     {
-        var host = baseAddress.Host;
-
-        // github.com REST lives at api.github.com; GraphQL is api.github.com/graphql.
-        if (host.Equals("api.github.com", StringComparison.OrdinalIgnoreCase)
-            || host.Equals("github.com", StringComparison.OrdinalIgnoreCase))
-        {
-            return new Uri("https://api.github.com/graphql");
-        }
-
-        // GitHub Enterprise Server: https://HOST/api/graphql.
-        return new Uri($"{baseAddress.Scheme}://{baseAddress.Authority}/api/graphql");
+        return GitHubHostAddress.GetGraphQLUriFromApiBase(baseAddress);
     }
 }

--- a/GitHubExtension/Client/GitHubHostAddress.cs
+++ b/GitHubExtension/Client/GitHubHostAddress.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace GitHubExtension.Client;
+
+// Central resolver for GitHub host addresses. Given a user-entered host (for
+// github.com or a GitHub Enterprise Server instance), it produces the Octokit
+// REST API base address and the GraphQL endpoint, keeping all host-specific URL
+// logic in one place so REST, GraphQL, and OAuth stay consistent.
+public static class GitHubHostAddress
+{
+    private const string GitHubComApiBase = "https://api.github.com/";
+    private const string GitHubComGraphQL = "https://api.github.com/graphql";
+
+    // Returns true when the host is github.com (in any of its common forms).
+    public static bool IsGitHubDotComHost(string host)
+    {
+        return host.Equals("github.com", StringComparison.OrdinalIgnoreCase)
+            || host.Equals("www.github.com", StringComparison.OrdinalIgnoreCase)
+            || host.Equals("api.github.com", StringComparison.OrdinalIgnoreCase);
+    }
+
+    // Normalizes a host string into an absolute Uri. Empty/whitespace resolves to
+    // github.com. A bare host such as "github.example.com" is assumed https.
+    public static Uri ParseHostInput(string? hostInput)
+    {
+        if (string.IsNullOrWhiteSpace(hostInput))
+        {
+            return new Uri("https://github.com");
+        }
+
+        var trimmed = hostInput.Trim();
+        if (!trimmed.Contains("://", StringComparison.Ordinal))
+        {
+            trimmed = "https://" + trimmed;
+        }
+
+        if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
+        {
+            throw new UriFormatException($"'{hostInput}' is not a valid host.");
+        }
+
+        if (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+        {
+            throw new UriFormatException($"'{hostInput}' must use http or https.");
+        }
+
+        return uri;
+    }
+
+    // The Octokit REST API base address for a host. github.com uses
+    // https://api.github.com/; GitHub Enterprise Server uses https://HOST/api/v3/.
+    public static Uri GetApiBaseUri(Uri host)
+    {
+        if (IsGitHubDotComHost(host.Host))
+        {
+            return new Uri(GitHubComApiBase);
+        }
+
+        return new Uri($"{host.Scheme}://{host.Authority}/api/v3/");
+    }
+
+    // The GraphQL endpoint for a host. github.com uses
+    // https://api.github.com/graphql; GHES uses https://HOST/api/graphql.
+    public static Uri GetGraphQLUri(Uri host)
+    {
+        if (IsGitHubDotComHost(host.Host))
+        {
+            return new Uri(GitHubComGraphQL);
+        }
+
+        return new Uri($"{host.Scheme}://{host.Authority}/api/graphql");
+    }
+
+    // Resolves the GraphQL endpoint from an Octokit REST base address (as exposed
+    // by IConnection.BaseAddress), covering both github.com and GHES.
+    public static Uri GetGraphQLUriFromApiBase(Uri apiBaseAddress)
+    {
+        if (IsGitHubDotComHost(apiBaseAddress.Host))
+        {
+            return new Uri(GitHubComGraphQL);
+        }
+
+        return new Uri($"{apiBaseAddress.Scheme}://{apiBaseAddress.Authority}/api/graphql");
+    }
+}

--- a/GitHubExtension/Controls/Commands/SignInCommand.cs
+++ b/GitHubExtension/Controls/Commands/SignInCommand.cs
@@ -35,6 +35,11 @@ public class SignInCommand : InvokableCommand, IDisposable
 
     public override CommandResult Invoke()
     {
+        return Invoke(string.Empty);
+    }
+
+    public CommandResult Invoke(string hostAddress)
+    {
         if (_invoked)
         {
             return CommandResult.KeepOpen();
@@ -46,7 +51,7 @@ public class SignInCommand : InvokableCommand, IDisposable
             _authenticationMediator.SetLoadingState(true);
             try
             {
-                var signInSucceeded = await _developerIdProvider.LoginNewDeveloperIdAsync();
+                var signInSucceeded = await _developerIdProvider.LoginNewDeveloperIdAsync(hostAddress ?? string.Empty);
                 _authenticationMediator.SetLoadingState(false);
                 _authenticationMediator.SignIn(new SignInStatusChangedEventArgs(true, null));
                 ToastHelper.ShowToast(_resources.GetResource("Message_Sign_In_Success"), MessageState.Success);

--- a/GitHubExtension/Controls/Forms/SignInForm.cs
+++ b/GitHubExtension/Controls/Forms/SignInForm.cs
@@ -77,13 +77,29 @@ public partial class SignInForm : FormContent, IDisposable
         { "{{AuthIcon}}", JsonSerializer.Serialize($"data:image/png;base64,{GitHubIcon.GetBase64Icon(GitHubIcon.LogoWithBackplatePath)}") },
         { "{{AuthButtonTooltip}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Sign_In_Tooltip")) },
         { "{{ButtonIsEnabled}}", JsonSerializer.Serialize(_isButtonEnabled) },
+        { "{{EnterpriseHostLabel}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Sign_In_EnterpriseHostLabel")) },
+        { "{{EnterpriseHostPlaceholder}}", JsonSerializer.Serialize(_resources.GetResource("Forms_Sign_In_EnterpriseHostPlaceholder")) },
     };
 
     public override string TemplateJson => TemplateHelper.LoadTemplateJsonFromTemplateName("AuthTemplate", TemplateSubstitutions);
 
     public override ICommandResult SubmitForm(string inputs, string data)
     {
-        return _signInCommand.Invoke();
+        var enterpriseHost = string.Empty;
+        if (!string.IsNullOrWhiteSpace(inputs))
+        {
+            try
+            {
+                var payload = System.Text.Json.Nodes.JsonNode.Parse(inputs);
+                enterpriseHost = payload?["EnterpriseHost"]?.ToString() ?? string.Empty;
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                enterpriseHost = string.Empty;
+            }
+        }
+
+        return _signInCommand.Invoke(enterpriseHost);
     }
 
     // Disposing area

--- a/GitHubExtension/Controls/Templates/AuthTemplate.json
+++ b/GitHubExtension/Controls/Templates/AuthTemplate.json
@@ -23,6 +23,13 @@
           "size": "large"
         },
         {
+          "type": "Input.Text",
+          "id": "EnterpriseHost",
+          "label": {{EnterpriseHostLabel}},
+          "placeholder": {{EnterpriseHostPlaceholder}},
+          "isRequired": false
+        },
+        {
           "type": "ColumnSet",
           "columns": [
             {

--- a/GitHubExtension/DeveloperId/DeveloperIdProvider.cs
+++ b/GitHubExtension/DeveloperId/DeveloperIdProvider.cs
@@ -66,9 +66,15 @@ public class DeveloperIdProvider : IDeveloperIdProvider
 
     public IAsyncOperation<IDeveloperId> LoginNewDeveloperIdAsync()
     {
+        return LoginNewDeveloperIdAsync(string.Empty);
+    }
+
+    public IAsyncOperation<IDeveloperId> LoginNewDeveloperIdAsync(string hostAddress)
+    {
         return Task.Run(() =>
         {
-            var oauthRequest = LoginNewDeveloperId();
+            var host = string.IsNullOrWhiteSpace(hostAddress) ? null : Client.GitHubHostAddress.ParseHostInput(hostAddress);
+            var oauthRequest = LoginNewDeveloperId(host);
             if (oauthRequest is null)
             {
                 _log.Error($"Invalid OAuthRequest");
@@ -86,9 +92,9 @@ public class DeveloperIdProvider : IDeveloperIdProvider
         }).AsAsyncOperation();
     }
 
-    private OAuthRequest? LoginNewDeveloperId()
+    private OAuthRequest? LoginNewDeveloperId(Uri? hostAddress = null)
     {
-        OAuthRequest oauthRequest = new();
+        OAuthRequest oauthRequest = new(hostAddress);
 
         lock (_oAuthRequestsLock)
         {

--- a/GitHubExtension/DeveloperId/IDeveloperIdProvider.cs
+++ b/GitHubExtension/DeveloperId/IDeveloperIdProvider.cs
@@ -16,6 +16,8 @@ public interface IDeveloperIdProvider
 
     IAsyncOperation<IDeveloperId> LoginNewDeveloperIdAsync();
 
+    IAsyncOperation<IDeveloperId> LoginNewDeveloperIdAsync(string hostAddress);
+
     bool LogoutDeveloperId(IDeveloperId developerId);
 
     void HandleOauthRedirection(Uri authorizationResponse);

--- a/GitHubExtension/DeveloperId/OAuthRequest.cs
+++ b/GitHubExtension/DeveloperId/OAuthRequest.cs
@@ -33,8 +33,15 @@ internal sealed class OAuthRequest : IDisposable
     }
 
     internal OAuthRequest()
+        : this(null)
     {
-        _gitHubClient = new(new ProductHeaderValue(Constants.CMDPAL_APPLICATION_NAME));
+    }
+
+    internal OAuthRequest(Uri? hostAddress)
+    {
+        _gitHubClient = hostAddress == null || Client.GitHubHostAddress.IsGitHubDotComHost(hostAddress.Host)
+            ? new(new ProductHeaderValue(Constants.CMDPAL_APPLICATION_NAME))
+            : new(new ProductHeaderValue(Constants.CMDPAL_APPLICATION_NAME), Client.GitHubHostAddress.GetApiBaseUri(hostAddress));
         _oAuthCompleted = new(0);
         State = string.Empty;
     }

--- a/GitHubExtension/Strings/en-US/Resources.resw
+++ b/GitHubExtension/Strings/en-US/Resources.resw
@@ -157,6 +157,14 @@
     <value>Sign in to GitHub</value>
     <comment>Shown in form's sign in button tooltip</comment>
   </data>
+  <data name="Forms_Sign_In_EnterpriseHostLabel" xml:space="preserve">
+    <value>GitHub Enterprise Server host (optional)</value>
+    <comment>Label for the optional enterprise host field on the sign in form</comment>
+  </data>
+  <data name="Forms_Sign_In_EnterpriseHostPlaceholder" xml:space="preserve">
+    <value>github.example.com (leave blank for github.com)</value>
+    <comment>Placeholder for the optional enterprise host field on the sign in form</comment>
+  </data>
   <data name="Forms_Sign_Out_Title" xml:space="preserve">
     <value>Are you sure you want to sign out?</value>
     <comment>Title for sign out form page</comment>


### PR DESCRIPTION
Final milestone of the RayCast parity roadmap. Stacked on top of #294 (M7).

## What this adds
Make the GitHub host configurable end-to-end so the extension can target a **GitHub Enterprise Server (GHES)** instance in addition to github.com.

- **Central host resolver** (\GitHubHostAddress\): normalizes a user-entered host (bare host assumes https, empty means github.com), detects github.com vs GHES, and produces the Octokit REST API base (\https://api.github.com/\ or \https://HOST/api/v3/\) and the GraphQL endpoint (\https://api.github.com/graphql\ or \https://HOST/api/graphql\).
- **Shared host logic**: \GitHubGraphQLClient\ now derives its endpoint through \GitHubHostAddress\, so REST and GraphQL host logic have one source of truth.
- **Host-aware OAuth**: \OAuthRequest\ accepts an optional host and builds its Octokit client against the enterprise API base; \IDeveloperIdProvider.LoginNewDeveloperIdAsync(host)\ threads the chosen host through sign-in. The parameterless path still defaults to github.com, and restored accounts already carry their own host.
- **Sign In form**: an optional 'GitHub Enterprise Server host' field (blank keeps github.com); \SignInCommand.Invoke(host)\ passes it through.

## Tests
- Host parsing (empty, bare, scheme, unsupported scheme), github.com vs GHES API/GraphQL resolution, and the GraphQL client delegation.
- **221/221 tests pass.**

## Notes
- OAuth against a live GHES instance can't be exercised in this environment; the host resolution and client construction are unit tested, and the flow reuses the existing github.com OAuth path.
- Per-account host was already supported when restoring saved accounts; this milestone extends it to the initial sign-in.