### PR TITLE
Add Codespaces Page

### DIFF
--- a/GitHubExtension.Test/Controls/CodespacesPageTest.cs
+++ b/GitHubExtension.Test/Controls/CodespacesPageTest.cs
@@ -1,0 +1,152 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using GitHubExtension.Client;
+using GitHubExtension.Controls.Pages;
+using GitHubExtension.DeveloperIds;
+using GitHubExtension.Helpers;
+using Moq;
+using Octokit;
+
+namespace GitHubExtension.Test.Controls;
+
+[TestClass]
+public class CodespacesPageTest
+{
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void CodespacesPageCreate_NotNull()
+    {
+        var resources = CreateResources();
+        var page = new CodespacesPage(resources.Object, CreateGitHubClientProvider(CreateCodespacesCollection(Array.Empty<Codespace>())));
+
+        Assert.IsNotNull(page);
+        Assert.IsTrue(page.IsLoading);
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void CodespacesPageGetItems_ReturnsCodespacesFromClient()
+    {
+        var resources = CreateResources();
+        var codespace = CreateCodespace("noraa/test-repo", "noraa-test", "Standard Linux", "Available", "https://github.com/codespaces/abc123");
+        var page = new CodespacesPage(resources.Object, CreateGitHubClientProvider(CreateCodespacesCollection([codespace])));
+
+        var previousPath = Environment.GetEnvironmentVariable("PATH");
+        var tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+        try
+        {
+            Directory.CreateDirectory(tempDirectory);
+            File.WriteAllText(Path.Combine(tempDirectory, "code"), string.Empty);
+            File.WriteAllText(Path.Combine(tempDirectory, "code-insiders"), string.Empty);
+            Environment.SetEnvironmentVariable("PATH", tempDirectory);
+
+            var items = page.GetItems();
+
+            Assert.AreEqual(1, items.Length);
+            Assert.AreEqual("noraa/test-repo", items[0].Title);
+            Assert.AreEqual("noraa-test - Standard Linux (Available)", items[0].Subtitle);
+            Assert.AreEqual(2, items[0].MoreCommands.Length);
+            Assert.IsFalse(page.IsLoading);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", previousPath);
+            if (Directory.Exists(tempDirectory))
+            {
+                Directory.Delete(tempDirectory, true);
+            }
+        }
+    }
+
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void CodespacesPageGetItems_WhenCodespacesApiFails_ReturnsErrorItem()
+    {
+        var resources = CreateResources();
+        var mockCodespacesClient = new Mock<ICodespacesClient>();
+        mockCodespacesClient.Setup(x => x.GetAll()).ThrowsAsync(new InvalidOperationException("Test failure"));
+
+        var page = new CodespacesPage(resources.Object, CreateGitHubClientProvider(mockCodespacesClient.Object));
+
+        var items = page.GetItems();
+
+        Assert.AreEqual(1, items.Length);
+        Assert.AreEqual("Codespaces failed", items[0].Title);
+        Assert.AreEqual("Unable to load codespaces", items[0].Subtitle);
+        Assert.IsFalse(page.IsLoading);
+    }
+
+    private static Mock<IResources> CreateResources()
+    {
+        var resources = new Mock<IResources>();
+        resources.Setup(x => x.GetResource("Pages_Codespaces", null)).Returns("Codespaces");
+        resources.Setup(x => x.GetResource("Pages_Codespaces_Placeholder", null)).Returns("Search codespaces");
+        resources.Setup(x => x.GetResource("Commands_Open_VS_Code", null)).Returns("Open in VS Code");
+        resources.Setup(x => x.GetResource("Commands_Open_VS_Code_Insiders", null)).Returns("Open in VS Code Insiders");
+        resources.Setup(x => x.GetResource("Message_Codespaces_LoadFail", null)).Returns("Codespaces failed");
+        resources.Setup(x => x.GetResource("Message_Codespaces_LoadFail_Description", null)).Returns("Unable to load codespaces");
+        return resources;
+    }
+
+    private static GitHubClientProvider CreateGitHubClientProvider(CodespacesCollection collection)
+    {
+        var codespacesClient = new Mock<ICodespacesClient>();
+        codespacesClient.Setup(x => x.GetAll()).ReturnsAsync(collection);
+
+        return CreateGitHubClientProvider(codespacesClient.Object);
+    }
+
+    private static GitHubClientProvider CreateGitHubClientProvider(ICodespacesClient codespacesClient)
+    {
+        var gitHubClient = new Mock<IGitHubClient>();
+        gitHubClient.Setup(x => x.Codespaces).Returns(codespacesClient);
+
+        var developerId = new Mock<IDeveloperId>();
+        developerId.Setup(x => x.LoginId).Returns("octocat");
+        developerId.Setup(x => x.GitHubClient).Returns(gitHubClient.Object);
+
+        var developerIdProvider = new Mock<IDeveloperIdProvider>();
+        developerIdProvider.Setup(x => x.GetLoggedInDeveloperIdsInternal()).Returns([developerId.Object]);
+
+        return new GitHubClientProvider(developerIdProvider.Object);
+    }
+
+    private static CodespacesCollection CreateCodespacesCollection(IReadOnlyList<Codespace> codespaces)
+    {
+        return new CodespacesCollection(codespaces, codespaces.Count);
+    }
+
+    private static Codespace CreateCodespace(string repositoryFullName, string name, string machineDisplayName, string state, string webUrl)
+    {
+        var repositoryParts = repositoryFullName.Split('/');
+        var owner = new User();
+        SetPrivateSetProperty(owner, nameof(User.Login), repositoryParts[0]);
+
+        var repository = new Repository();
+        SetPrivateSetProperty(repository, nameof(Repository.Owner), owner);
+        SetPrivateSetProperty(repository, nameof(Repository.Name), repositoryParts[1]);
+
+        var machine = new Machine();
+        SetPrivateSetProperty(machine, nameof(Machine.DisplayName), machineDisplayName);
+
+        var codespace = new Codespace();
+        SetPrivateSetProperty(codespace, nameof(Codespace.Name), name);
+        SetPrivateSetProperty(codespace, nameof(Codespace.Repository), repository);
+        SetPrivateSetProperty(codespace, nameof(Codespace.Machine), machine);
+        SetPrivateSetProperty(codespace, nameof(Codespace.State), new StringEnum<CodespaceState>(state));
+        SetPrivateSetProperty(codespace, nameof(Codespace.WebUrl), webUrl);
+
+        return codespace;
+    }
+
+    private static void SetPrivateSetProperty<T, TValue>(T target, string propertyName, TValue value)
+    {
+        var property = typeof(T).GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public)
+            ?? throw new InvalidOperationException($"Property {propertyName} not found on {typeof(T).Name}");
+        property.SetValue(target, value);
+    }
+}

--- a/GitHubExtension.Test/Helpers/TestSetupHelpers.cs
+++ b/GitHubExtension.Test/Helpers/TestSetupHelpers.cs
@@ -170,6 +170,7 @@ public partial class TestHelpers
         var mockSignInForm = new Mock<SignInForm>(mockAuthenticationMediator, mockResources, mockDeveloperIdProvider, mockSignInCommand).Object;
         var signOutPage = new SignOutPage(mockResources, mockSignOutForm, mockSignOutCommand, mockAuthenticationMediator);
         var signInPage = new SignInPage(mockSignInForm, mockResources, mockSignInCommand, mockAuthenticationMediator);
-        return new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, mockDeveloperIdProvider, persistentDataManager, mockResources, searchPageFactory, savedSearchesMediator, mockAuthenticationMediator);
+        var codespacesPage = new CodespacesPage(mockResources, new Client.GitHubClientProvider(mockDeveloperIdProvider));
+        return new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, mockDeveloperIdProvider, persistentDataManager, mockResources, searchPageFactory, savedSearchesMediator, mockAuthenticationMediator, codespacesPage);
     }
 }

--- a/GitHubExtension/Assets/vscode-insiders.svg
+++ b/GitHubExtension/Assets/vscode-insiders.svg
@@ -1,0 +1,37 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="256" height="256">
+<path d="M176.049 250.669C180.838 255.459 188.13 256.7 194.234 253.764L246.94 228.419C252.478 225.755 256 220.154 256 214.008V42.1479C256 36.0025 252.478 30.4008 246.94 27.7374L194.234 2.39089C188.13 -0.544416 180.838 0.696607 176.049 5.48572C181.95 -0.41506 192.039 3.76413 192.039 12.1091V244.046C192.039 252.391 181.95 256.57 176.049 250.669Z" fill="white"/>
+<path d="M181.379 180.646L114.33 128.633L181.379 75.5114V17.794C181.379 10.8477 173.128 7.20673 167.996 11.8862L74.6514 97.8518L31.1994 64.1438C27.1081 61.039 21.3851 61.294 17.5853 64.7476L3.48974 77.5627C-1.15847 81.7893 -1.16367 89.0948 3.47672 93.3292L167.98 244.185C173.107 248.887 181.379 245.249 181.379 238.292V180.646Z" fill="white"/>
+<path d="M36.6937 134.195L3.47672 162.828C-1.16367 167.062 -1.15847 174.37 3.48974 178.594L17.5853 191.409C21.3851 194.863 27.1081 195.118 31.1994 192.013L69.4472 164.057L36.6937 134.195Z" fill="white"/>
+</mask>
+<g mask="url(#mask0)">
+<path d="M167.996 11.8857C173.128 7.20627 181.379 10.8473 181.379 17.7936V75.5109L104.938 136.073L65.5742 106.211L167.996 11.8857Z" fill="#009A7C"/>
+<path d="M36.6937 134.194L3.47672 162.827C-1.16367 167.062 -1.15847 174.37 3.48974 178.594L17.5853 191.409C21.3851 194.863 27.1081 195.118 31.1994 192.013L69.4472 164.056L36.6937 134.194Z" fill="#009A7C"/>
+<g filter="url(#filter0_d)">
+<path d="M181.379 180.645L31.1994 64.1427C27.1081 61.0379 21.3851 61.2929 17.5853 64.7465L3.48974 77.5616C-1.15847 81.7882 -1.16367 89.0937 3.47672 93.3281L167.972 244.176C173.102 248.881 181.379 245.241 181.379 238.28V180.645Z" fill="#00B294"/>
+</g>
+<g filter="url(#filter1_d)">
+<path d="M194.233 253.766C188.13 256.701 180.837 255.46 176.048 250.671C181.949 256.571 192.039 252.392 192.039 244.047V12.1103C192.039 3.76535 181.949 -0.413839 176.048 5.48694C180.837 0.697824 188.129 -0.543191 194.233 2.3921L246.939 27.7386C252.478 30.402 256 36.0037 256 42.1491V214.009C256 220.155 252.478 225.757 246.939 228.42L194.233 253.766Z" fill="#24BFA5"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_d" x="-21.3333" y="40.6413" width="224.045" height="226.988" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="10.6667"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.15 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+<filter id="filter1_d" x="154.715" y="-20.5169" width="122.618" height="297.191" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="10.6667"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="overlay" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/GitHubExtension/Assets/vscode.svg
+++ b/GitHubExtension/Assets/vscode.svg
@@ -1,0 +1,41 @@
+<svg viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="100" height="100">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M70.9119 99.3171C72.4869 99.9307 74.2828 99.8914 75.8725 99.1264L96.4608 89.2197C98.6242 88.1787 100 85.9892 100 83.5872V16.4133C100 14.0113 98.6243 11.8218 96.4609 10.7808L75.8725 0.873756C73.7862 -0.130129 71.3446 0.11576 69.5135 1.44695C69.252 1.63711 69.0028 1.84943 68.769 2.08341L29.3551 38.0415L12.1872 25.0096C10.589 23.7965 8.35363 23.8959 6.86933 25.2461L1.36303 30.2549C-0.452552 31.9064 -0.454633 34.7627 1.35853 36.417L16.2471 50.0001L1.35853 63.5832C-0.454633 65.2374 -0.452552 68.0938 1.36303 69.7453L6.86933 74.7541C8.35363 76.1043 10.589 76.2037 12.1872 74.9905L29.3551 61.9587L68.769 97.9167C69.3925 98.5406 70.1246 99.0104 70.9119 99.3171ZM75.0152 27.2989L45.1091 50.0001L75.0152 72.7012V27.2989Z" fill="white"/>
+</mask>
+<g mask="url(#mask0)">
+<path d="M96.4614 10.7962L75.8569 0.875542C73.4719 -0.272773 70.6217 0.211611 68.75 2.08333L1.29858 63.5832C-0.515693 65.2373 -0.513607 68.0937 1.30308 69.7452L6.81272 74.754C8.29793 76.1042 10.5347 76.2036 12.1338 74.9905L93.3609 13.3699C96.086 11.3026 100 13.2462 100 16.6667V16.4275C100 14.0265 98.6246 11.8378 96.4614 10.7962Z" fill="#0065A9"/>
+<g filter="url(#filter0_d)">
+<path d="M96.4614 89.2038L75.8569 99.1245C73.4719 100.273 70.6217 99.7884 68.75 97.9167L1.29858 36.4169C-0.515693 34.7627 -0.513607 31.9063 1.30308 30.2548L6.81272 25.246C8.29793 23.8958 10.5347 23.7964 12.1338 25.0095L93.3609 86.6301C96.086 88.6974 100 86.7538 100 83.3334V83.5726C100 85.9735 98.6246 88.1622 96.4614 89.2038Z" fill="#007ACC"/>
+</g>
+<g filter="url(#filter1_d)">
+<path d="M75.8578 99.1263C73.4721 100.274 70.6219 99.7885 68.75 97.9166C71.0564 100.223 75 98.5895 75 95.3278V4.67213C75 1.41039 71.0564 -0.223106 68.75 2.08329C70.6219 0.211402 73.4721 -0.273666 75.8578 0.873633L96.4587 10.7807C98.6234 11.8217 100 14.0112 100 16.4132V83.5871C100 85.9891 98.6234 88.1786 96.4586 89.2196L75.8578 99.1263Z" fill="#1F9CF0"/>
+</g>
+<g style="mix-blend-mode:overlay" opacity="0.25">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M70.8511 99.3171C72.4261 99.9306 74.2221 99.8913 75.8117 99.1264L96.4 89.2197C98.5634 88.1787 99.9392 85.9892 99.9392 83.5871V16.4133C99.9392 14.0112 98.5635 11.8217 96.4001 10.7807L75.8117 0.873695C73.7255 -0.13019 71.2838 0.115699 69.4527 1.44688C69.1912 1.63705 68.942 1.84937 68.7082 2.08335L29.2943 38.0414L12.1264 25.0096C10.5283 23.7964 8.29285 23.8959 6.80855 25.246L1.30225 30.2548C-0.513334 31.9064 -0.515415 34.7627 1.29775 36.4169L16.1863 50L1.29775 63.5832C-0.515415 65.2374 -0.513334 68.0937 1.30225 69.7452L6.80855 74.754C8.29285 76.1042 10.5283 76.2036 12.1264 74.9905L29.2943 61.9586L68.7082 97.9167C69.3317 98.5405 70.0638 99.0104 70.8511 99.3171ZM74.9544 27.2989L45.0483 50L74.9544 72.7012V27.2989Z" fill="url(#paint0_linear)"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_d" x="-8.39411" y="15.8291" width="116.727" height="92.2456" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="4.16667"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="overlay" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+<filter id="filter1_d" x="60.4167" y="-8.07558" width="47.9167" height="116.151" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="4.16667"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="overlay" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+<linearGradient id="paint0_linear" x1="49.9392" y1="0.257812" x2="49.9392" y2="99.7423" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+</defs>
+</svg>

--- a/GitHubExtension/Controls/Pages/CodespacesPage.cs
+++ b/GitHubExtension/Controls/Pages/CodespacesPage.cs
@@ -11,7 +11,7 @@ using Octokit;
 
 namespace GitHubExtension.Controls.Pages;
 
-public sealed class CodespacesPage : ListPage
+public sealed partial class CodespacesPage : ListPage
 {
     private readonly GitHubClientProvider _gitHubClientProvider;
     private readonly IResources _resources;

--- a/GitHubExtension/Controls/Pages/CodespacesPage.cs
+++ b/GitHubExtension/Controls/Pages/CodespacesPage.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using GitHubExtension.Client;
+using GitHubExtension.Helpers;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Octokit;
+
+namespace GitHubExtension.Controls.Pages;
+
+public sealed class CodespacesPage : ListPage
+{
+    private readonly GitHubClientProvider _gitHubClientProvider;
+    private readonly IResources _resources;
+
+    public CodespacesPage(IResources resources, GitHubClientProvider gitHubClientProvider)
+    {
+        _gitHubClientProvider = gitHubClientProvider;
+        _resources = resources;
+        Icon = GitHubIcon.IconDictionary["logo"];
+        Title = resources.GetResource("Pages_Codespaces");
+        Name = Title; // Title is for the Page, Name is for the Command
+        this.PlaceholderText = resources.GetResource("Pages_Codespaces_Placeholder");
+        this.IsLoading = true;
+    }
+
+    public override IListItem[] GetItems()
+    {
+        CodespacesCollection codespaces = _gitHubClientProvider.GetClientForLoggedInDeveloper().Result.Codespaces.GetAll().Result;
+        List<IListItem> result = [];
+        try
+        {
+            foreach (Codespace c in codespaces.Codespaces)
+            {
+                List<IContextItem> moreCommands = [];
+
+                if (IsExecutableInPath("code-insiders"))
+                {
+                    moreCommands.Add(new CommandContextItem(new OpenUrlCommand("vscode-insiders://github.codespaces/connect?name=" + c.Name + "&windowId=_blank") { Name = _resources.GetResource("Commands_Open_VS_Code_Insiders"), Icon = IconHelpers.FromRelativePath("Assets\\vscode-insiders.svg") }));
+                }
+
+                if (IsExecutableInPath("code"))
+                {
+                    moreCommands.Add(new CommandContextItem(new OpenUrlCommand("vscode://github.codespaces/connect?name=" + c.Name + "&windowId=_blank") { Name = _resources.GetResource("Commands_Open_VS_Code"), Icon = IconHelpers.FromRelativePath("Assets\\vscode.svg") }));
+                }
+
+                result.Add(new ListItem(new OpenUrlCommand(c.WebUrl))
+                {
+                    Title = $"{c.Repository.Owner.Login}/{c.Repository.Name}",
+                    Subtitle = $"{c.Name} - {c.Machine.DisplayName} ({c.State.StringValue})",
+                    Icon = GitHubIcon.IconDictionary["logo"],
+                    MoreCommands = [.. moreCommands],
+                });
+            }
+        }
+        catch (Exception)
+        {
+            this.IsLoading = false;
+            return [new ListItem(new NoOpCommand()) { Title = _resources.GetResource("Message_Codespaces_LoadFail"), Subtitle = _resources.GetResource("Message_Codespaces_LoadFail_Description") }];
+        }
+
+        this.IsLoading = false;
+        return [.. result];
+    }
+
+    private bool IsExecutableInPath(string searchPath)
+    {
+        var values = Environment.GetEnvironmentVariable("PATH");
+        if (values is null)
+        {
+            return false;
+        }
+
+        foreach (var path in values.Split(Path.PathSeparator))
+        {
+            var fullPath = Path.Combine(path, searchPath);
+            if (File.Exists(fullPath))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/GitHubExtension/Controls/Pages/CodespacesPage.cs
+++ b/GitHubExtension/Controls/Pages/CodespacesPage.cs
@@ -6,6 +6,7 @@ using GitHubExtension.Client;
 using GitHubExtension.Helpers;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.UI.Xaml.Controls;
 using Octokit;
 
 namespace GitHubExtension.Controls.Pages;
@@ -31,7 +32,8 @@ public sealed class CodespacesPage : ListPage
         List<IListItem> result = [];
         try
         {
-            CodespacesCollection codespaces = _gitHubClientProvider.GetClientForLoggedInDeveloper().Result.Codespaces.GetAll().Result;
+            IGitHubClient gitHubClient = _gitHubClientProvider.GetClientForLoggedInDeveloper().Result;
+            CodespacesCollection codespaces = gitHubClient.Codespaces.GetAll().Result;
 
             foreach (Codespace c in codespaces.Codespaces)
             {
@@ -46,6 +48,11 @@ public sealed class CodespacesPage : ListPage
                 {
                     moreCommands.Add(new CommandContextItem(new OpenUrlCommand("vscode://github.codespaces/connect?name=" + Uri.EscapeDataString(c.Name) + "&windowId=_blank") { Name = _resources.GetResource("Commands_Open_VS_Code"), Icon = IconHelpers.FromRelativePath("Assets\\vscode.svg") }));
                 }
+
+                moreCommands.Add(new CommandContextItem(new CopyTextCommand(c.WebUrl) { Name = _resources.GetResource("Commands_Copy_Codespace_URL"), Icon = new IconInfo("\uE8C8") }));
+
+                moreCommands.Add(new CommandContextItem(new AnonymousCommand(() => { gitHubClient.Codespaces.Start(c.Name); }) { Name = _resources.GetResource("Commands_Start_Codespace"), Icon = new IconInfo("\uE768") }));
+                moreCommands.Add(new CommandContextItem(new AnonymousCommand(() => { gitHubClient.Codespaces.Stop(c.Name); }) { Name = _resources.GetResource("Commands_Stop_Codespace"), Icon = new IconInfo("\uE71A") }));
 
                 result.Add(new ListItem(new OpenUrlCommand(c.WebUrl))
                 {

--- a/GitHubExtension/Controls/Pages/CodespacesPage.cs
+++ b/GitHubExtension/Controls/Pages/CodespacesPage.cs
@@ -28,22 +28,23 @@ public sealed class CodespacesPage : ListPage
 
     public override IListItem[] GetItems()
     {
-        CodespacesCollection codespaces = _gitHubClientProvider.GetClientForLoggedInDeveloper().Result.Codespaces.GetAll().Result;
         List<IListItem> result = [];
         try
         {
+            CodespacesCollection codespaces = _gitHubClientProvider.GetClientForLoggedInDeveloper().Result.Codespaces.GetAll().Result;
+
             foreach (Codespace c in codespaces.Codespaces)
             {
                 List<IContextItem> moreCommands = [];
 
                 if (IsExecutableInPath("code-insiders"))
                 {
-                    moreCommands.Add(new CommandContextItem(new OpenUrlCommand("vscode-insiders://github.codespaces/connect?name=" + c.Name + "&windowId=_blank") { Name = _resources.GetResource("Commands_Open_VS_Code_Insiders"), Icon = IconHelpers.FromRelativePath("Assets\\vscode-insiders.svg") }));
+                    moreCommands.Add(new CommandContextItem(new OpenUrlCommand("vscode-insiders://github.codespaces/connect?name=" + Uri.EscapeDataString(c.Name) + "&windowId=_blank") { Name = _resources.GetResource("Commands_Open_VS_Code_Insiders"), Icon = IconHelpers.FromRelativePath("Assets\\vscode-insiders.svg") }));
                 }
 
                 if (IsExecutableInPath("code"))
                 {
-                    moreCommands.Add(new CommandContextItem(new OpenUrlCommand("vscode://github.codespaces/connect?name=" + c.Name + "&windowId=_blank") { Name = _resources.GetResource("Commands_Open_VS_Code"), Icon = IconHelpers.FromRelativePath("Assets\\vscode.svg") }));
+                    moreCommands.Add(new CommandContextItem(new OpenUrlCommand("vscode://github.codespaces/connect?name=" + Uri.EscapeDataString(c.Name) + "&windowId=_blank") { Name = _resources.GetResource("Commands_Open_VS_Code"), Icon = IconHelpers.FromRelativePath("Assets\\vscode.svg") }));
                 }
 
                 result.Add(new ListItem(new OpenUrlCommand(c.WebUrl))

--- a/GitHubExtension/DeveloperId/OAuthRequest.cs
+++ b/GitHubExtension/DeveloperId/OAuthRequest.cs
@@ -61,7 +61,7 @@ internal sealed class OAuthRequest : IDisposable
 
         var request = new OauthLoginRequest(OauthConfiguration.GetClientId())
         {
-            Scopes = { "read:user", "notifications", "repo", "read:org", "write:org" },
+            Scopes = { "read:user", "notifications", "repo", "read:org", "write:org", "codespace" },
             State = State,
             RedirectUri = new Uri(OauthConfiguration.RedirectUri),
         };

--- a/GitHubExtension/GitHubExtensionCommandsProvider.cs
+++ b/GitHubExtension/GitHubExtensionCommandsProvider.cs
@@ -17,6 +17,7 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
     private readonly SavedSearchesPage _savedSearchesPage;
     private readonly SignOutPage _signOutPage;
     private readonly SignInPage _signInPage;
+    private readonly CodespacesPage _codespacesPage;
     private readonly IDeveloperIdProvider _developerIdProvider;
     private readonly ISearchRepository _persistentDataManager;
     private readonly ISearchPageFactory _searchPageFactory;
@@ -33,7 +34,8 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
         IResources resources,
         ISearchPageFactory searchPageFactory,
         SavedSearchesMediator savedSearchesMediator,
-        AuthenticationMediator authenticationMediator)
+        AuthenticationMediator authenticationMediator,
+        CodespacesPage codespacesPage)
     {
         _savedSearchesPage = savedSearchesPage;
         _signOutPage = signOutPage;
@@ -44,6 +46,7 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
         _searchPageFactory = searchPageFactory;
         _savedSearchesMediator = savedSearchesMediator;
         _authenticationMediator = authenticationMediator;
+        _codespacesPage = codespacesPage;
 
         DisplayName = _resources.GetResource("ExtensionTitle");
 
@@ -94,6 +97,7 @@ public partial class GitHubExtensionCommandsProvider : CommandProvider, IDisposa
         {
             new(_savedSearchesPage),
             new(_signOutPage),
+            new(_codespacesPage),
         };
 
         commands.AddRange(defaultCommands);

--- a/GitHubExtension/Program.cs
+++ b/GitHubExtension/Program.cs
@@ -146,7 +146,9 @@ public class Program
         using var signInForm = new SignInForm(authenticationMediator, resources, developerIdProvider, signInCommand);
         using var signInPage = new SignInPage(signInForm, resources, signInCommand, authenticationMediator);
 
-        using var commandProvider = new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, developerIdProvider, searchRepository, resources, searchPageFactory, savedSearchesMediator, authenticationMediator);
+        var codespacesPage = new CodespacesPage(resources, gitHubClientProvider);
+
+        using var commandProvider = new GitHubExtensionCommandsProvider(savedSearchesPage, signOutPage, signInPage, developerIdProvider, searchRepository, resources, searchPageFactory, savedSearchesMediator, authenticationMediator, codespacesPage);
         var extensionInstance = new GitHubExtension(extensionDisposedEvent, commandProvider);
 
         // We are instantiating an extension instance once above, and returning it every time the callback in RegisterExtension below is called.

--- a/GitHubExtension/Strings/en-US/Resources.resw
+++ b/GitHubExtension/Strings/en-US/Resources.resw
@@ -419,4 +419,13 @@
   <data name="Message_Codespaces_LoadFail_Description" xml:space="preserve">
     <value>You may need to log out and log in again to get the necessary permissions</value>
   </data>
+  <data name="Commands_Start_Codespace" xml:space="preserve">
+    <value>Start Codespace</value>
+  </data>
+  <data name="Commands_Stop_Codespace" xml:space="preserve">
+    <value>Stop Codespace</value>
+  </data>
+  <data name="Commands_Copy_Codespace_URL" xml:space="preserve">
+    <value>Copy Codespace URL</value>
+  </data>
 </root>

--- a/GitHubExtension/Strings/en-US/Resources.resw
+++ b/GitHubExtension/Strings/en-US/Resources.resw
@@ -401,4 +401,25 @@
     <value>Sign in to the GitHub Extension (Preview)</value>
     <comment>The title for the SignInPage</comment>
   </data>
+  <data name="Pages_Codespaces" xml:space="preserve">
+    <value>Your Codespaces</value>
+  </data>
+  <data name="Pages_Codespaces_Placeholder" xml:space="preserve">
+    <value>Search Codespaces</value>
+  </data>
+  <data name="Commands_Open_VS_Code" xml:space="preserve">
+    <value>Open in Visual Studio Code</value>
+  </data>
+  <data name="Commands_Open_VS_Code1" xml:space="preserve">
+    <value>Open in Visual Studio Code</value>
+  </data>
+  <data name="Commands_Open_VS_Code_Insiders" xml:space="preserve">
+    <value>Open in Visual Studio Code Insiders</value>
+  </data>
+  <data name="Message_Codespaces_LoadFail" xml:space="preserve">
+    <value>There was an error loading your codespaces</value>
+  </data>
+  <data name="Message_Codespaces_LoadFail_Description" xml:space="preserve">
+    <value>You may need to log out and log in again to get the necessary permissions</value>
+  </data>
 </root>

--- a/GitHubExtension/Strings/en-US/Resources.resw
+++ b/GitHubExtension/Strings/en-US/Resources.resw
@@ -410,9 +410,6 @@
   <data name="Commands_Open_VS_Code" xml:space="preserve">
     <value>Open in Visual Studio Code</value>
   </data>
-  <data name="Commands_Open_VS_Code1" xml:space="preserve">
-    <value>Open in Visual Studio Code</value>
-  </data>
   <data name="Commands_Open_VS_Code_Insiders" xml:space="preserve">
     <value>Open in Visual Studio Code Insiders</value>
   </data>


### PR DESCRIPTION
Adds a codespaces page to the GitHub extension, where the logged in user sees all their with system information and current status.

<img width="902" height="130" alt="image" src="https://github.com/user-attachments/assets/fcb44075-d336-4288-a44c-51fd1fa717d9" />

<img width="287" height="245" alt="image" src="https://github.com/user-attachments/assets/14be39d1-d80e-4236-9bc9-cc9f7f97e394" />


If VS Code is installed it shows an option to open the codespace in VS Code. Same for VS Code insiders.

As this requires additional permissions, existing users will see this error until they log out and log in again:
<img width="1117" height="592" alt="image" src="https://github.com/user-attachments/assets/df20072c-66af-42d8-a5a9-950038f1277f" />
