### PR TITLE
Move to .NET 10 (net10.0-windows, SDK 10.0.110)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,25 +14,27 @@ permissions:
 jobs:
   build-and-test:
     strategy:
+      fail-fast: false
       matrix:
-        configuration: [Release]
-        platform: [x64, arm64]
-        dotnet-version: ['8.0.x']
-    runs-on: windows-latest
+        include:
+          - platform: x64
+            os: windows-latest
+            configuration: Release
+          - platform: arm64
+            os: windows-11-vs2026-arm
+            configuration: Release
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
       with:
         clean: true
 
-    - name: Setup .NET SDK ${{ matrix.dotnet-version }}
+    - name: Setup .NET SDK (from global.json)
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: ${{ matrix.dotnet-version }}
         global-json-file: global.json
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v2
-      with:
-        vs-version: '17.5'
 
     - name: Download nuget
       run: |
@@ -53,7 +55,6 @@ jobs:
       run: cmd /c "$env:VSDevCmd" "&" msbuild /p:Configuration=${{ matrix.configuration }},Platform=${{ matrix.platform }} /restore GitHubExtension.sln
 
     - name: Find vstest.console.exe
-      if: ${{ matrix.platform != 'arm64' }}
       run: |
         $VSDevTestCmd = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere" -latest -prerelease -products * -find **\TestPlatform\vstest.console.exe
         if (!$VSDevTestCmd) { exit 1 }
@@ -61,5 +62,4 @@ jobs:
         Add-Content $env:GITHUB_ENV "VSDevTestCmd=$VSDevTestCmd"
 
     - name: UnitTests
-      if: ${{ matrix.platform != 'arm64' }}
       run: cmd /c "$env:VSDevTestCmd" /Platform:${{ matrix.platform }} /TestCaseFilter:"TestCategory!=LiveData" BuildOutput\\${{ matrix.configuration }}\\${{ matrix.platform }}\\GitHubExtension.Test\\GitHubExtension.Test.dll

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,6 +34,7 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
+        global-json-file: global.json
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v2
       with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,14 +17,8 @@ jobs:
       matrix:
         configuration: [Release]
         platform: [x64, arm64]
-        os: [windows-latest, windows-11-arm]
         dotnet-version: ['8.0.x']
-        exclude:
-        - os: windows-latest
-          platform: arm64
-        - os: windows-11-arm
-          platform: x64
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
       with:
@@ -59,6 +53,7 @@ jobs:
       run: cmd /c "$env:VSDevCmd" "&" msbuild /p:Configuration=${{ matrix.configuration }},Platform=${{ matrix.platform }} /restore GitHubExtension.sln
 
     - name: Find vstest.console.exe
+      if: ${{ matrix.platform != 'arm64' }}
       run: |
         $VSDevTestCmd = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere" -latest -prerelease -products * -find **\TestPlatform\vstest.console.exe
         if (!$VSDevTestCmd) { exit 1 }
@@ -66,4 +61,5 @@ jobs:
         Add-Content $env:GITHUB_ENV "VSDevTestCmd=$VSDevTestCmd"
 
     - name: UnitTests
+      if: ${{ matrix.platform != 'arm64' }}
       run: cmd /c "$env:VSDevTestCmd" /Platform:${{ matrix.platform }} /TestCaseFilter:"TestCategory!=LiveData" BuildOutput\\${{ matrix.configuration }}\\${{ matrix.platform }}\\GitHubExtension.Test\\GitHubExtension.Test.dll

--- a/Common.Dotnet.CsWinRT.props
+++ b/Common.Dotnet.CsWinRT.props
@@ -14,7 +14,7 @@
     <WarningLevel>4</WarningLevel>
     <NoWarn></NoWarn>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <WarningsNotAsErrors>CA1720;CA1859;CA2263;CA2022;MVVMTK0045;MVVMTK0049;CsWinRT1028;CsWinRT1029;CsWinRT1030;CsWinRT1031;CsWinRT1032;CsWinRT1033</WarningsNotAsErrors>
+    <WarningsNotAsErrors>CA1720;CA1859;CA2263;CA2022;MVVMTK0045;MVVMTK0049</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/Common.Dotnet.CsWinRT.props
+++ b/Common.Dotnet.CsWinRT.props
@@ -2,8 +2,8 @@
 <!-- Some items may be set in Directory.Build.props in root -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <WindowsSdkPackageVersion>10.0.26100.42</WindowsSdkPackageVersion>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <WindowsSdkPackageVersion>10.0.26100.87</WindowsSdkPackageVersion>
+    <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
@@ -14,7 +14,7 @@
     <WarningLevel>4</WarningLevel>
     <NoWarn></NoWarn>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <WarningsNotAsErrors>CA1720;CA1859;CA2263;CA2022;MVVMTK0045;MVVMTK0049</WarningsNotAsErrors>
+    <WarningsNotAsErrors>CA1720;CA1859;CA2263;CA2022;MVVMTK0045;MVVMTK0049;CsWinRT1028;CsWinRT1029;CsWinRT1030;CsWinRT1031;CsWinRT1032;CsWinRT1033</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,6 +18,7 @@
     <PackageTags>GITServices</PackageTags>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisMode>Recommended</AnalysisMode>
+    <NuGetAuditMode>direct</NuGetAuditMode>
     <PlatformTarget>$(Platform)</PlatformTarget>
     <SelfContained>false</SelfContained>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>

--- a/GitHubExtension/Controls/Commands/SignInCommand.cs
+++ b/GitHubExtension/Controls/Commands/SignInCommand.cs
@@ -9,7 +9,7 @@ using Microsoft.CommandPalette.Extensions.Toolkit;
 
 namespace GitHubExtension.Controls.Commands;
 
-public class SignInCommand : InvokableCommand, IDisposable
+public partial class SignInCommand : InvokableCommand, IDisposable
 {
     private readonly IResources _resources;
     private readonly IDeveloperIdProvider _developerIdProvider;

--- a/GitHubExtension/Controls/Commands/SignOutCommand.cs
+++ b/GitHubExtension/Controls/Commands/SignOutCommand.cs
@@ -9,7 +9,7 @@ using Microsoft.CommandPalette.Extensions.Toolkit;
 
 namespace GitHubExtension.Controls.Commands;
 
-public class SignOutCommand : InvokableCommand, IDisposable
+public partial class SignOutCommand : InvokableCommand, IDisposable
 {
     private readonly IResources _resources;
     private readonly IDeveloperIdProvider _developerIdProvider;

--- a/GitHubExtension/GitHubExtension.csproj
+++ b/GitHubExtension/GitHubExtension.csproj
@@ -33,7 +33,7 @@
       <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
       <PackageReference Include="MessageFormat" Version="6.0.2" />
       <PackageReference Include="Microsoft.CommandPalette.Extensions" Version="0.1.0" />
-      <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.1" />
+      <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
       <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -51,7 +51,7 @@ extends:
         break: false
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared
-      image: windows-2022
+      image: windows-2025
       os: windows
 
     stages:

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.110",
-    "rollForward": "latestMinor",
+    "version": "9.0.119",
+    "rollForward": "latestPatch",
     "allowPrerelease": false
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "9.0.119",
-    "rollForward": "latestPatch",
+    "rollForward": "latestFeature",
     "allowPrerelease": false
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.119",
+    "version": "10.0.110",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.110",
+    "rollForward": "latestMinor",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
## Summary

Moves the extension to **.NET 10**.

### Changes
- **Target framework**: `net9.0-windows` → `net10.0-windows10.0.26100.0` (`WindowsSdkPackageVersion` → `10.0.26100.87`).
- **`global.json`**: pins the .NET SDK to `10.0.110` with `rollForward: latestFeature` — uses the newest installed .NET 10 SDK at or above that floor. CI installs it via `global-json-file`.
- **Dependencies**: `Microsoft.Data.Sqlite` → `10.0.10`.
- **Build config**: `NuGetAuditMode=direct` (audit direct dependencies — same as the PowerToys CmdPal template).

### CsWinRT source-generator requirements on net10 (why the `partial` edits are here)
Upgrading the TFM to net10 also updates the CsWinRT toolchain. On net10, **every class that implements a Command Palette WinRT interface** (e.g. `InvokableCommand`) must be declared `partial` so the generator can emit the ABI projection into a generated partial. Without `partial`, CsWinRT raises **CsWinRT1028**, which fails the `TreatWarningsAsErrors` build.

The affected classes are therefore marked `partial` — the sanctioned fix — rather than suppressing the diagnostic:
- **Commands**: `SignInCommand`, `SignOutCommand`

This is a net10-driven build requirement, not a behavior change — no runtime logic is altered by adding `partial`.

### CI
- **x64** — builds and runs unit tests on `windows-latest` (VS 2026 / MSBuild 18, required by the .NET 10 SDK).
- **arm64** — builds and runs unit tests **natively** on `windows-11-vs2026-arm` (VS 2026).
- The SDK is installed solely from `global.json`.

Both legs are green.

> Note: `windows-11-vs2026-arm` is currently a GitHub public-preview runner image. If a GA-only runner is required, the arm64 leg can cross-build on `windows-latest` with arm64 tests skipped.
