### PR TITLE
Update Microsoft.Data.Sqlite to 10.0.11

### DIFF
--- a/GitHubExtension.Test/DataStoreTests/DataObjectTests.cs
+++ b/GitHubExtension.Test/DataStoreTests/DataObjectTests.cs
@@ -7,11 +7,25 @@ using GitHubExtension.DataModel;
 using GitHubExtension.DataModel.DataObjects;
 using GitHubExtension.Helpers;
 using GitHubExtension.Test.Helpers;
+using Microsoft.Data.Sqlite;
 
 namespace GitHubExtension.Test.DataStoreTests;
 
 public partial class DataStoreTests
 {
+    [TestMethod]
+    [TestCategory("Unit")]
+    public void NativeSqliteVersionMeetsMinimum()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT sqlite_version()";
+        var version = Convert.ToString(command.ExecuteScalar(), System.Globalization.CultureInfo.InvariantCulture);
+        Assert.IsTrue(Version.TryParse(version, out var nativeVersion), $"Invalid SQLite version: {version}");
+        Assert.IsTrue(nativeVersion >= new Version(3, 50, 2), $"SQLite 3.50.2 or newer is required; loaded {version}.");
+    }
+
     [TestMethod]
     [TestCategory("Unit")]
     public void DateTimeExtension()

--- a/GitHubExtension.Test/DataStoreTests/DataObjectTests.cs
+++ b/GitHubExtension.Test/DataStoreTests/DataObjectTests.cs
@@ -7,25 +7,11 @@ using GitHubExtension.DataModel;
 using GitHubExtension.DataModel.DataObjects;
 using GitHubExtension.Helpers;
 using GitHubExtension.Test.Helpers;
-using Microsoft.Data.Sqlite;
 
 namespace GitHubExtension.Test.DataStoreTests;
 
 public partial class DataStoreTests
 {
-    [TestMethod]
-    [TestCategory("Unit")]
-    public void NativeSqliteVersionMeetsMinimum()
-    {
-        using var connection = new SqliteConnection("Data Source=:memory:");
-        connection.Open();
-        using var command = connection.CreateCommand();
-        command.CommandText = "SELECT sqlite_version()";
-        var version = Convert.ToString(command.ExecuteScalar(), System.Globalization.CultureInfo.InvariantCulture);
-        Assert.IsTrue(Version.TryParse(version, out var nativeVersion), $"Invalid SQLite version: {version}");
-        Assert.IsTrue(nativeVersion >= new Version(3, 50, 2), $"SQLite 3.50.2 or newer is required; loaded {version}.");
-    }
-
     [TestMethod]
     [TestCategory("Unit")]
     public void DateTimeExtension()

--- a/GitHubExtension/GitHubExtension.csproj
+++ b/GitHubExtension/GitHubExtension.csproj
@@ -33,7 +33,7 @@
       <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
       <PackageReference Include="MessageFormat" Version="6.0.2" />
       <PackageReference Include="Microsoft.CommandPalette.Extensions" Version="0.1.0" />
-      <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
+      <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.11" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
       <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
@@ -45,7 +45,6 @@
       <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
       <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
       <PackageReference Include="Shmuelie.WinRTServer" Version="2.1.1" />
-      <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
   </ItemGroup>
 
     <ItemGroup>

--- a/GitHubExtension/GitHubExtension.csproj
+++ b/GitHubExtension/GitHubExtension.csproj
@@ -45,6 +45,7 @@
       <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
       <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
       <PackageReference Include="Shmuelie.WinRTServer" Version="2.1.1" />
+      <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
   </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary

Update the existing direct dependency `Microsoft.Data.Sqlite` from **10.0.10 to 10.0.11**. This is the only code change in this PR.

## Why this version

`Microsoft.Data.Sqlite 10.0.10` selects SQLitePCLRaw **2.1.11**, including the old native SQLite package. The **10.0.11** package declares dependencies on SQLitePCLRaw bundle/core **2.1.12**, so updating the higher-level dependency brings in the updated native library without an explicit transitive-package override.

Resolved dependency chain:

```text
Microsoft.Data.Sqlite 10.0.11
  -> SQLitePCLRaw.bundle_e_sqlite3 2.1.12
     -> SQLitePCLRaw.lib.e_sqlite3 2.1.12 (native SQLite 3.53.3)
```

No additional package references, version-assertion tests, database schema changes, or save-behavior changes. The existing `PowerToysPublicDependencies` NuGet configuration is unchanged.

## Validation

- Restored through the existing feed and confirmed the application dependency graph selects the 2.1.12 native package rather than 2.1.11.
- Existing Release x64 datastore/persistence tests passed; no new tests were added.
- Native SQLite 3.53.3 was confirmed from the restored 2.1.12 Windows x64 DLL.
- CI and official Component Governance scan confirmation remain pending; this PR does not claim dashboard alert closure.